### PR TITLE
ignore using to generate quip table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix Bug - Handle unsigned long in sorting order assertion of LongHashSet ([#17207](https://github.com/opensearch-project/OpenSearch/pull/17207))
 - Implemented computation of segment replication stats at shard level ([#17055](https://github.com/opensearch-project/OpenSearch/pull/17055))
 - [Rule Based Auto-tagging] Add in-memory attribute value store ([#17342](https://github.com/opensearch-project/OpenSearch/pull/17342))
+-  Add Balanced Docs Slice Allocator to increase document balance for Concurrent Segment Search ([#17687](https://github.com/opensearch-project/OpenSearch/pull/17687))
 
 ### Dependencies
 - Bump `org.awaitility:awaitility` from 4.2.0 to 4.3.0 ([#17230](https://github.com/opensearch-project/OpenSearch/pull/17230), [#17439](https://github.com/opensearch-project/OpenSearch/pull/17439))

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -437,7 +437,6 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ShardsLimitAllocationDecider.CLUSTER_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING,
                 NodeConnectionsService.CLUSTER_NODE_RECONNECT_INTERVAL_SETTING,
                 HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_TYPE_SETTING,
-                ContextIndexSearcher.CLUSTER_USE_EXPERIMENTAL_SLICE,
                 HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_TYPE_SETTING,
                 TransportReplicationAction.REPLICATION_INITIAL_RETRY_BACKOFF_BOUND,
                 TransportReplicationAction.REPLICATION_RETRY_TIMEOUT,

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -164,6 +164,7 @@ import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
 import org.opensearch.search.backpressure.settings.SearchShardTaskSettings;
 import org.opensearch.search.backpressure.settings.SearchTaskSettings;
 import org.opensearch.search.fetch.subphase.highlight.FastVectorHighlighter;
+import org.opensearch.search.internal.ContextIndexSearcher;
 import org.opensearch.snapshots.InternalSnapshotsInfoService;
 import org.opensearch.snapshots.SnapshotsService;
 import org.opensearch.tasks.TaskCancellationMonitoringSettings;
@@ -436,6 +437,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ShardsLimitAllocationDecider.CLUSTER_TOTAL_PRIMARY_SHARDS_PER_NODE_SETTING,
                 NodeConnectionsService.CLUSTER_NODE_RECONNECT_INTERVAL_SETTING,
                 HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_TYPE_SETTING,
+                ContextIndexSearcher.CLUSTER_USE_EXPERIMENTAL_SLICE,
                 HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_TYPE_SETTING,
                 TransportReplicationAction.REPLICATION_INITIAL_RETRY_BACKOFF_BOUND,
                 TransportReplicationAction.REPLICATION_RETRY_TIMEOUT,

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -164,7 +164,6 @@ import org.opensearch.search.backpressure.settings.SearchBackpressureSettings;
 import org.opensearch.search.backpressure.settings.SearchShardTaskSettings;
 import org.opensearch.search.backpressure.settings.SearchTaskSettings;
 import org.opensearch.search.fetch.subphase.highlight.FastVectorHighlighter;
-import org.opensearch.search.internal.ContextIndexSearcher;
 import org.opensearch.snapshots.InternalSnapshotsInfoService;
 import org.opensearch.snapshots.SnapshotsService;
 import org.opensearch.tasks.TaskCancellationMonitoringSettings;
@@ -769,6 +768,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_SETTING, // deprecated
                 SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING,
                 SearchService.CLUSTER_CONCURRENT_SEGMENT_SEARCH_MODE,
+                SearchService.CONCURRENT_SEGMENT_SEARCH_USE_EXPERIMENTAL_SLICING_SETTING,
 
                 RemoteStoreSettings.CLUSTER_REMOTE_INDEX_SEGMENT_METADATA_RETENTION_MAX_COUNT_SETTING,
                 RemoteStoreSettings.CLUSTER_REMOTE_TRANSLOG_BUFFER_INTERVAL_SETTING,

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -732,6 +732,13 @@ public final class IndexSettings {
         Property.IndexScope
     );
 
+    public static final Setting<Boolean> INDEX_CONCURRENT_SEGMENT_SEARCH_SHOULD_USE_EXPERIMENTAL_BALANCED_SLICING = Setting.boolSetting(
+        "index.search.concurrent.experimental_slicing.enable",
+        false,
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
     public static final Setting<Boolean> INDEX_DOC_ID_FUZZY_SET_ENABLED_SETTING = Setting.boolSetting(
         "index.optimize_doc_id_lookup.fuzzy_set.enabled",
         false,

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -249,7 +249,8 @@ final class DefaultSearchContext extends SearchContext {
             lowLevelCancellation,
             concurrentSearchMode.equals(CONCURRENT_SEGMENT_SEARCH_MODE_AUTO)
                 || concurrentSearchMode.equals(CONCURRENT_SEGMENT_SEARCH_MODE_ALL) ? executor : null,
-            this
+            this,
+            clusterService
         );
         this.relativeTimeSupplier = relativeTimeSupplier;
         this.timeout = timeout;

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -250,7 +250,6 @@ final class DefaultSearchContext extends SearchContext {
             concurrentSearchMode.equals(CONCURRENT_SEGMENT_SEARCH_MODE_AUTO)
                 || concurrentSearchMode.equals(CONCURRENT_SEGMENT_SEARCH_MODE_ALL) ? executor : null,
             this
-
         );
         this.relativeTimeSupplier = relativeTimeSupplier;
         this.timeout = timeout;
@@ -1103,6 +1102,19 @@ final class DefaultSearchContext extends SearchContext {
                 clusterService.getClusterSettings().get(SearchService.CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_SETTING)
             );
 
+    }
+
+    @Override
+    public boolean shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch() {
+        if (shouldUseConcurrentSearch() == false) {
+            throw new IllegalStateException("Experimental slicing cannot be enabled when concurrent search is disabled");
+        }
+        return indexService.getIndexSettings()
+            .getSettings()
+            .getAsBoolean(
+                IndexSettings.INDEX_CONCURRENT_SEGMENT_SEARCH_SHOULD_USE_EXPERIMENTAL_BALANCED_SLICING.getKey(),
+                clusterService.getClusterSettings().get(SearchService.CONCURRENT_SEGMENT_SEARCH_USE_EXPERIMENTAL_SLICING_SETTING)
+            );
     }
 
     @Override

--- a/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/DefaultSearchContext.java
@@ -249,8 +249,8 @@ final class DefaultSearchContext extends SearchContext {
             lowLevelCancellation,
             concurrentSearchMode.equals(CONCURRENT_SEGMENT_SEARCH_MODE_AUTO)
                 || concurrentSearchMode.equals(CONCURRENT_SEGMENT_SEARCH_MODE_ALL) ? executor : null,
-            this,
-            clusterService
+            this
+
         );
         this.relativeTimeSupplier = relativeTimeSupplier;
         this.timeout = timeout;

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -308,6 +308,16 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Property.NodeScope
     );
 
+    public static final String CONCURRENT_SEGMENT_SEARCH_USE_EXPERIMENTAL_SLICING_KEY = "search.concurrent.experimental_slicing.enable";
+    public static final boolean CONCURRENT_SEGMENT_SEARCH_USE_EXPERIMENTAL_SLICING_DEFAULT_VALUE = false;
+
+    public static final Setting<Boolean> CONCURRENT_SEGMENT_SEARCH_USE_EXPERIMENTAL_SLICING_SETTING = Setting.boolSetting(
+        CONCURRENT_SEGMENT_SEARCH_USE_EXPERIMENTAL_SLICING_KEY,
+        CONCURRENT_SEGMENT_SEARCH_USE_EXPERIMENTAL_SLICING_DEFAULT_VALUE,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
     // value 0 means rewrite filters optimization in aggregations will be disabled
     public static final Setting<Integer> MAX_AGGREGATION_REWRITE_FILTERS = Setting.intSetting(
         "search.max_aggregation_rewrite_filters",

--- a/server/src/main/java/org/opensearch/search/internal/BalancedDocsSliceSupplier.java
+++ b/server/src/main/java/org/opensearch/search/internal/BalancedDocsSliceSupplier.java
@@ -1,0 +1,205 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.internal;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+/**
+ * @opensearch.internal
+ * @opensearch.experimental
+ * This class is experimental and may be changed or removed completely
+ * in a future release without warning
+ */
+final class BalancedDocsSliceSupplier {
+
+    private static final Logger logger = LogManager.getLogger(BalancedDocsSliceSupplier.class);
+
+    /**
+     * Creates balanced slices based on leaf reader sizes
+     *
+     * @param leaves List of LeafReaderContext to be sliced
+     * @param targetMaxSlice Maximum number of desired slices
+     * @return Array of LeafSlice containing balanced distribution of readers
+     */
+     static IndexSearcher.LeafSlice[] getSlicesv0(List<LeafReaderContext> leaves, int targetMaxSlice) {
+        if (leaves == null || leaves.isEmpty()) {
+            return new IndexSearcher.LeafSlice[0];
+        }
+
+        if (targetMaxSlice <= 1 || leaves.size() == 1) {
+            return new IndexSearcher.LeafSlice[]{new IndexSearcher.LeafSlice(leaves)};
+        }
+
+        // Calculate sizes for each leaf
+        Map<Integer, Long> leafSizes = new HashMap<>();
+        long totalDocs = 0;
+        for (int i = 0; i < leaves.size(); i++) {
+            long size = leaves.get(i).reader().maxDoc();
+            leafSizes.put(i, size);
+            totalDocs += size;
+        }
+
+        // Calculate actual number of slices (min of target and leaf count)
+        int actualSlices = Math.min(targetMaxSlice, leaves.size());
+        long targetDocsPerSlice = totalDocs / actualSlices;
+
+        // Create slices
+        List<List<LeafReaderContext>> groupedLeaves = new ArrayList<>();
+        List<LeafReaderContext> currentSlice = new ArrayList<>();
+        long currentSliceSize = 0;
+
+        // Sort leaves by size for better distribution
+        List<Map.Entry<Integer, Long>> sortedLeaves = new ArrayList<>(leafSizes.entrySet());
+        sortedLeaves.sort(Map.Entry.<Integer, Long>comparingByValue().reversed());
+
+        for (Map.Entry<Integer, Long> entry : sortedLeaves) {
+            int leafIndex = entry.getKey();
+            long leafSize = entry.getValue();
+
+            // If adding this leaf would exceed target size and we haven't reached last slice,
+            // start a new slice
+            if (currentSliceSize > 0 &&
+                currentSliceSize + leafSize > targetDocsPerSlice &&
+                groupedLeaves.size() < actualSlices - 1) {
+                groupedLeaves.add(currentSlice);
+                currentSlice = new ArrayList<>();
+                currentSliceSize = 0;
+            }
+
+            currentSlice.add(leaves.get(leafIndex));
+            currentSliceSize += leafSize;
+        }
+
+        // Add the last slice if it's not empty
+        if (!currentSlice.isEmpty()) {
+            groupedLeaves.add(currentSlice);
+        }
+
+        return groupedLeaves.stream().map(IndexSearcher.LeafSlice::new).toArray(IndexSearcher.LeafSlice[]::new);
+    }
+
+    static IndexSearcher.LeafSlice[] getSlicesV1(List<LeafReaderContext> leaves, int targetMaxSlice) {
+        if (leaves == null || leaves.isEmpty()) {
+            return new IndexSearcher.LeafSlice[0];
+        }
+
+        if (targetMaxSlice <= 1 || leaves.size() == 1) {
+            return new IndexSearcher.LeafSlice[]{new IndexSearcher.LeafSlice(leaves)};
+        }
+
+        // Calculate sizes
+        long[] sizes = new long[leaves.size()];
+        long totalDocs = 0;
+        for (int i = 0; i < leaves.size(); i++) {
+            sizes[i] = leaves.get(i).reader().maxDoc();
+            totalDocs += sizes[i];
+        }
+
+        int actualSlices = Math.min(targetMaxSlice, leaves.size());
+        long targetDocsPerSlice = totalDocs / actualSlices;
+
+        // Initialize slices
+        List<List<LeafReaderContext>> groupedLeaves = new ArrayList<>();
+        for (int i = 0; i < actualSlices; i++) {
+            groupedLeaves.add(new ArrayList<>());
+        }
+
+        // Create pairs of (index, size) and sort by size
+        Integer[] indices = new Integer[leaves.size()];
+        for (int i = 0; i < leaves.size(); i++) {
+            indices[i] = i;
+        }
+        Arrays.sort(indices, (a, b) -> Long.compare(sizes[b], sizes[a]));
+
+        // Distribute leaves using a greedy approach
+        for (int i = 0; i < indices.length; i++) {
+            int leafIndex = indices[i];
+
+            // Find the slice with the smallest current total that can fit this leaf
+            int bestSlice = 0;
+            long minTotal = getSliceTotal(groupedLeaves.get(0), leaves);
+
+            for (int j = 1; j < groupedLeaves.size(); j++) {
+                long sliceTotal = getSliceTotal(groupedLeaves.get(j), leaves);
+                if (sliceTotal < minTotal) {
+                    minTotal = sliceTotal;
+                    bestSlice = j;
+                }
+            }
+
+            groupedLeaves.get(bestSlice).add(leaves.get(leafIndex));
+        }
+
+        // Remove empty slices and convert to array
+        groupedLeaves.removeIf(List::isEmpty);
+        return groupedLeaves.stream()
+            .map(IndexSearcher.LeafSlice::new)
+            .toArray(IndexSearcher.LeafSlice[]::new);
+    }
+
+    private static long getSliceTotal(List<LeafReaderContext> slice, List<LeafReaderContext> allLeaves) {
+        return slice.stream()
+            .mapToLong(leaf -> leaf.reader().maxDoc())
+            .sum();
+    }
+
+    public static IndexSearcher.LeafSlice[] getSlicesV2(List<LeafReaderContext> leaves, int targetMaxSlice) {
+        if (targetMaxSlice <= 0) {
+            throw new IllegalArgumentException("Target max slice must be > 0 but got: " + targetMaxSlice);
+        }
+
+        // Ensure the number of slices does not exceed the number of leaves.
+        int targetSliceCount = Math.min(targetMaxSlice, leaves.size());
+
+        // Make a copy and sort the leaves in descending order by maxDoc.
+        List<LeafReaderContext> sortedLeaves = new ArrayList<>(leaves);
+        sortedLeaves.sort(Collections.reverseOrder(Comparator.comparingInt(l -> l.reader().maxDoc())));
+
+        // Helper class to hold a group of leaves and their cumulative document count.
+        class SliceGroup {
+            final List<LeafReaderContext> groupLeaves = new ArrayList<>();
+            long totalDocs = 0;
+        }
+
+        // Create a priority queue (min-heap) keyed on the totalDocs of each group.
+        PriorityQueue<SliceGroup> queue = new PriorityQueue<>(Comparator.comparingLong(g -> g.totalDocs));
+        for (int i = 0; i < targetSliceCount; i++) {
+            queue.add(new SliceGroup());
+        }
+
+        // Process each leaf in descending order and assign it to the slice with the lowest totalDocs.
+        for (LeafReaderContext leaf : sortedLeaves) {
+            SliceGroup currentGroup = queue.poll();  // get the slice with the smallest totalDocs
+            assert currentGroup != null;
+            currentGroup.groupLeaves.add(leaf);
+            currentGroup.totalDocs += leaf.reader().maxDoc();
+            queue.add(currentGroup); // reinsert after updating the totalDocs
+        }
+
+        // Convert the SliceGroups to an array of LeafSlice objects.
+        List<IndexSearcher.LeafSlice> slices = new ArrayList<>();
+        for (SliceGroup group : queue) {
+            slices.add(new IndexSearcher.LeafSlice(group.groupLeaves));
+        }
+
+        return slices.toArray(new IndexSearcher.LeafSlice[0]);
+    }
+}

--- a/server/src/main/java/org/opensearch/search/internal/BalancedDocsSliceSupplier.java
+++ b/server/src/main/java/org/opensearch/search/internal/BalancedDocsSliceSupplier.java
@@ -13,8 +13,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
 
 /**
  * @opensearch.internal
@@ -34,7 +37,7 @@ final class BalancedDocsSliceSupplier {
      *
      * @param leaves List of LeafReaderContext to be sliced
      * @param targetMaxSlice Maximum number of desired slices
-     * @return Array of LeafSlice containing balanced distribution of readers
+     * @return Array of LeafSlice containing balanced distribution of readers;
      */
     public static IndexSearcher.LeafSlice[] getSlices(List<LeafReaderContext> leaves, int targetMaxSlice) {
         if (targetMaxSlice <= 0) {

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -602,8 +602,10 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             logger.debug("Slice count using lucene default [{}]", leafSlices.length);
         } else {
             // use the custom slice calculation based on targetMaxSlice
-            leafSlices = MaxTargetSliceSupplier.getSlices(leaves, targetMaxSlice);
-            logger.debug("Slice count using max target slice supplier [{}]", leafSlices.length);
+            // possible TODO is to see if there are any performance regressions on the current method; if so, change based on the SearchContext value.
+//            leafSlices = MaxTargetSliceSupplier.getSlices(leaves, targetMaxSlice);
+            leafSlices = BalancedDocsSliceSupplier.getSlices(leaves, targetMaxSlice);
+            logger.debug("Slice count using balanced docs slice supplier [{}]", leafSlices.length);
         }
         return leafSlices;
     }

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -600,14 +600,14 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         if (targetMaxSlice == 0) {
             // use the default lucene slice calculation
             leafSlices = super.slices(leaves);
-            logger.info("Slice count using lucene default [{}]", leafSlices.length);
+            logger.debug("Slice count using lucene default [{}]", leafSlices.length);
         } else if (shouldUseMaxTargetSlice()) {
             // use the custom slice calculation based on targetMaxSlice
             leafSlices = MaxTargetSliceSupplier.getSlices(leaves, targetMaxSlice);
-            logger.info("Slice count using max target slice supplier [{}]", leafSlices.length);
+            logger.debug("Slice count using max target slice supplier [{}]", leafSlices.length);
         } else {
             leafSlices = BalancedDocsSliceSupplier.getSlices(leaves, targetMaxSlice);
-            logger.info("Slice count using balanced docs slice supplier [{}]", leafSlices.length);
+            logger.debug("Slice count using balanced docs slice supplier [{}]", leafSlices.length);
         }
         return leafSlices;
     }

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -67,7 +67,6 @@ import org.apache.lucene.util.SparseFixedBitSet;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lucene.search.TopDocsAndMaxScore;
-import org.opensearch.common.settings.Setting;
 import org.opensearch.lucene.util.CombinedBitSet;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchService;

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -113,13 +113,6 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
     private MutableQueryTimeout cancellable;
     private SearchContext searchContext;
 
-    public static final Setting<Boolean> CLUSTER_USE_EXPERIMENTAL_SLICE = Setting.boolSetting(
-        "cluster.indices.experimental_slicing.enable",
-        false,
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
-
     public ContextIndexSearcher(
         IndexReader reader,
         Similarity similarity,

--- a/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/FilteredSearchContext.java
@@ -579,6 +579,11 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
+    public boolean shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch() {
+        return in.shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch();
+    }
+
+    @Override
     public boolean shouldUseTimeSeriesDescSortOptimization() {
         return in.shouldUseTimeSeriesDescSortOptimization();
     }

--- a/server/src/main/java/org/opensearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/opensearch/search/internal/SearchContext.java
@@ -516,6 +516,8 @@ public abstract class SearchContext implements Releasable {
 
     public abstract int getTargetMaxSliceCount();
 
+    public abstract boolean shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch();
+
     public abstract boolean shouldUseTimeSeriesDescSortOptimization();
 
     public int maxAggRewriteFilters() {

--- a/server/src/test/java/org/opensearch/search/internal/BalancedDocsSliceSupplierTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/BalancedDocsSliceSupplierTests.java
@@ -15,9 +15,9 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.opensearch.search.internal.IndexReaderUtils.getLeaves;
 import static org.apache.lucene.search.IndexSearcher.LeafReaderContextPartition;
 import static org.apache.lucene.search.IndexSearcher.LeafSlice;
-import static org.opensearch.search.internal.IndexReaderUtils.getLeaves;
 
 public class BalancedDocsSliceSupplierTests extends OpenSearchTestCase {
     public void testSliceCountGreaterThanLeafCount() throws Exception {
@@ -30,8 +30,7 @@ public class BalancedDocsSliceSupplierTests extends OpenSearchTestCase {
     }
 
     public void testNegativeSliceCount() {
-        assertThrows(IllegalArgumentException.class,
-            () -> BalancedDocsSliceSupplier.getSlices(new ArrayList<>(), randomIntBetween(-3, 0)));
+        assertThrows(IllegalArgumentException.class, () -> BalancedDocsSliceSupplier.getSlices(new ArrayList<>(), randomIntBetween(-3, 0)));
     }
 
     public void testSingleSliceWithMultipleLeaves() throws Exception {
@@ -43,7 +42,7 @@ public class BalancedDocsSliceSupplierTests extends OpenSearchTestCase {
 
     public void testBalancedDistribution() throws Exception {
         // Create leaves with varying document counts
-        List<LeafReaderContext> leaves = IndexReaderUtils.getLeavesWithDocCounts(new int[]{1000, 800, 600, 400, 200});
+        List<LeafReaderContext> leaves = IndexReaderUtils.getLeavesWithDocCounts(new int[] { 1000, 800, 600, 400, 200 });
 
         int targetSlices = 2;
         LeafSlice[] slices = BalancedDocsSliceSupplier.getSlices(leaves, targetSlices);
@@ -69,19 +68,18 @@ public class BalancedDocsSliceSupplierTests extends OpenSearchTestCase {
     }
 
     public void testLargestSlicesFirst() throws Exception {
-        List<LeafReaderContext> leaves = IndexReaderUtils.getLeavesWithDocCounts(new int[]{1000, 500, 250});
+        List<LeafReaderContext> leaves = IndexReaderUtils.getLeavesWithDocCounts(new int[] { 1000, 500, 250 });
 
         LeafSlice[] slices = BalancedDocsSliceSupplier.getSlices(leaves, 2);
 
         // Verify that the slice with more documents comes first
         long firstSliceDocs = getTotalDocs(slices[0]);
         long secondSliceDocs = getTotalDocs(slices[1]);
-        assertTrue("First slice should have more or equal documents than second slice",
-            firstSliceDocs >= secondSliceDocs);
+        assertTrue("First slice should have more or equal documents than second slice", firstSliceDocs >= secondSliceDocs);
     }
 
     public void testEvenDistributionWithEqualSizedLeaves() throws Exception {
-        int[] docsPerLeaf = new int[]{100, 100, 100, 100, 100, 100};
+        int[] docsPerLeaf = new int[] { 100, 100, 100, 100, 100, 100 };
         int leafCount = docsPerLeaf.length;
         List<LeafReaderContext> leaves = IndexReaderUtils.getLeavesWithDocCounts(docsPerLeaf);
 
@@ -92,11 +90,10 @@ public class BalancedDocsSliceSupplierTests extends OpenSearchTestCase {
         assertEquals(leafCount / targetSlices, slices[0].partitions.length);
         assertEquals(leafCount / targetSlices, slices[1].partitions.length);
     }
+
     public void testJaggedDistribution() throws Exception {
         // Very uneven distribution
-        int[] docCounts = new int[] {
-            1658,202,160,9,64,2,175,185,4,1
-        };
+        int[] docCounts = new int[] { 1658, 202, 160, 9, 64, 2, 175, 185, 4, 1 };
 
         List<LeafReaderContext> leaves = IndexReaderUtils.getLeavesWithDocCounts(docCounts);
         int targetSlices = 8;
@@ -110,17 +107,16 @@ public class BalancedDocsSliceSupplierTests extends OpenSearchTestCase {
         for (int i = 0; i < slices.length; i++) {
             for (IndexSearcher.LeafReaderContextPartition partition : slices[i].partitions) {
                 docsInSlice[i] += partition.ctx.reader().maxDoc();
-                totalDocs  += partition.ctx.reader().maxDoc();
+                totalDocs += partition.ctx.reader().maxDoc();
             }
         }
 
         assertEquals("Total document count should match", 2460, totalDocs);
         // ensure 2,4,1 all assigned to last slice
-        assertEquals(docsInSlice[targetSlices-1], 7);
+        assertEquals(docsInSlice[targetSlices - 1], 7);
     }
 
-
-        private long getTotalDocs(LeafSlice slice) {
+    private long getTotalDocs(LeafSlice slice) {
         long total = 0;
         for (LeafReaderContextPartition partition : slice.partitions) {
             total += partition.ctx.reader().maxDoc();

--- a/server/src/test/java/org/opensearch/search/internal/BalancedDocsSliceSupplierTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/BalancedDocsSliceSupplierTests.java
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.search.internal;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.IndexSearcher;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.lucene.search.IndexSearcher.LeafReaderContextPartition;
+import static org.apache.lucene.search.IndexSearcher.LeafSlice;
+import static org.opensearch.search.internal.IndexReaderUtils.getLeaves;
+
+public class BalancedDocsSliceSupplierTests extends OpenSearchTestCase {
+    public void testSliceCountGreaterThanLeafCount() throws Exception {
+        int expectedSliceCount = 2;
+        LeafSlice[] slices = BalancedDocsSliceSupplier.getSlices(getLeaves(expectedSliceCount), 5);
+        assertEquals(expectedSliceCount, slices.length);
+        for (int i = 0; i < expectedSliceCount; ++i) {
+            assertEquals(1, slices[i].partitions.length);
+        }
+    }
+
+    public void testNegativeSliceCount() {
+        assertThrows(IllegalArgumentException.class,
+            () -> BalancedDocsSliceSupplier.getSlices(new ArrayList<>(), randomIntBetween(-3, 0)));
+    }
+
+    public void testSingleSliceWithMultipleLeaves() throws Exception {
+        int leafCount = randomIntBetween(1, 10);
+        LeafSlice[] slices = BalancedDocsSliceSupplier.getSlices(getLeaves(leafCount), 1);
+        assertEquals(1, slices.length);
+        assertEquals(leafCount, slices[0].partitions.length);
+    }
+
+    public void testBalancedDistribution() throws Exception {
+        // Create leaves with varying document counts
+        List<LeafReaderContext> leaves = IndexReaderUtils.getLeavesWithDocCounts(new int[]{1000, 800, 600, 400, 200});
+
+        int targetSlices = 2;
+        LeafSlice[] slices = BalancedDocsSliceSupplier.getSlices(leaves, targetSlices);
+
+        assertEquals(targetSlices, slices.length);
+
+        // Calculate total docs in each slice
+        long[] docsInSlice = new long[targetSlices];
+        for (int i = 0; i < slices.length; i++) {
+            for (LeafReaderContextPartition partition : slices[i].partitions) {
+                docsInSlice[i] += partition.ctx.reader().maxDoc();
+            }
+        }
+
+        // Verify that the difference between slices is minimal
+        long diff = Math.abs(docsInSlice[0] - docsInSlice[1]);
+        assertTrue("Difference between slice sizes should be minimal", diff <= 400);
+    }
+
+    public void testEmptyLeaves() {
+        LeafSlice[] slices = BalancedDocsSliceSupplier.getSlices(new ArrayList<>(), 2);
+        assertEquals(0, slices.length);
+    }
+
+    public void testLargestSlicesFirst() throws Exception {
+        List<LeafReaderContext> leaves = IndexReaderUtils.getLeavesWithDocCounts(new int[]{1000, 500, 250});
+
+        LeafSlice[] slices = BalancedDocsSliceSupplier.getSlices(leaves, 2);
+
+        // Verify that the slice with more documents comes first
+        long firstSliceDocs = getTotalDocs(slices[0]);
+        long secondSliceDocs = getTotalDocs(slices[1]);
+        assertTrue("First slice should have more or equal documents than second slice",
+            firstSliceDocs >= secondSliceDocs);
+    }
+
+    public void testEvenDistributionWithEqualSizedLeaves() throws Exception {
+        int[] docsPerLeaf = new int[]{100, 100, 100, 100, 100, 100};
+        int leafCount = docsPerLeaf.length;
+        List<LeafReaderContext> leaves = IndexReaderUtils.getLeavesWithDocCounts(docsPerLeaf);
+
+        int targetSlices = 2;
+        LeafSlice[] slices = BalancedDocsSliceSupplier.getSlices(leaves, targetSlices);
+
+        assertEquals(targetSlices, slices.length);
+        assertEquals(leafCount / targetSlices, slices[0].partitions.length);
+        assertEquals(leafCount / targetSlices, slices[1].partitions.length);
+    }
+    public void testJaggedDistribution() throws Exception {
+        // Very uneven distribution
+        int[] docCounts = new int[] {
+            1658,202,160,9,64,2,175,185,4,1
+        };
+
+        List<LeafReaderContext> leaves = IndexReaderUtils.getLeavesWithDocCounts(docCounts);
+        int targetSlices = 8;
+        IndexSearcher.LeafSlice[] slices = BalancedDocsSliceSupplier.getSlices(leaves, targetSlices);
+
+        assertEquals(targetSlices, slices.length);
+
+        // Calculate docs per slice and total docs
+        long[] docsInSlice = new long[targetSlices];
+        long totalDocs = 0;
+        for (int i = 0; i < slices.length; i++) {
+            for (IndexSearcher.LeafReaderContextPartition partition : slices[i].partitions) {
+                docsInSlice[i] += partition.ctx.reader().maxDoc();
+                totalDocs  += partition.ctx.reader().maxDoc();
+            }
+        }
+
+        assertEquals("Total document count should match", 2460, totalDocs);
+        // ensure 2,4,1 all assigned to last slice
+        assertEquals(docsInSlice[targetSlices-1], 7);
+    }
+
+
+        private long getTotalDocs(LeafSlice slice) {
+        long total = 0;
+        for (LeafReaderContextPartition partition : slice.partitions) {
+            total += partition.ctx.reader().maxDoc();
+        }
+        return total;
+    }
+}

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -399,8 +399,9 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                     null,
                     searchContext
                 );
-                // Case 1: Verify getSlices returns not null when concurrent segment search is disabled
                 assertEquals(1, searcher.getSlices().length);
+                
+                // Case 1: Verify getSlices returns not null when concurrent segment search is disabled
 
                 // Case 2: Verify the slice count when custom max slice computation is used
                 searcher = new ContextIndexSearcher(
@@ -436,11 +437,11 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
 
     public void testSlicesInternalWithScrollContext() throws Exception {
         final List<LeafReaderContext> leaves = getLeaves(10);
-        try (Directory directory = newDirectory()) {
+        try (Directory directory = newDirectory();
             IndexWriter iw = new IndexWriter(
                 directory,
                 new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
-            );
+            );) {
 
             Document document = new Document();
             document.add(new StringField("field1", "value1", Field.Store.NO));

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -83,6 +83,9 @@ import org.opensearch.index.shard.SearchOperationListener;
 import org.opensearch.lucene.util.CombinedBitSet;
 import org.opensearch.search.SearchService;
 import org.opensearch.search.aggregations.LeafBucketCollector;
+import org.opensearch.search.internal.ExitableDirectoryReader.ExitableLeafReader;
+import org.opensearch.search.internal.ExitableDirectoryReader.ExitablePointValues;
+import org.opensearch.search.internal.ExitableDirectoryReader.ExitableTerms;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -354,18 +357,15 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 expectedSliceCount = 4;
                 slices = searcher.slicesInternal(leaves, expectedSliceCount);
 
-                // 4 slices will be created with 3 leaves in 2 slices and 2 leaves in other slices
-                // BalancedDocSliceSupplier uses a PQ to assign segments to slices, so the slice assignment is different
-                // than round-robin approach.
-                int num_slices_with_length_2 = 0;
-                int num_slices_with_length_3 = 0;
+                // 4 slices will be created with 3 leaves in first 2 slices and 2 leaves in other slices
                 assertEquals(expectedSliceCount, slices.length);
                 for (int i = 0; i < expectedSliceCount; ++i) {
-                    if (slices[i].partitions.length == 2) num_slices_with_length_2++;
-                    else if (slices[i].partitions.length == 3) num_slices_with_length_3++;
+                    if (i < 2) {
+                        assertEquals(3, slices[i].partitions.length);
+                    } else {
+                        assertEquals(2, slices[i].partitions.length);
+                    }
                 }
-                assertEquals(2, num_slices_with_length_2);
-                assertEquals(2, num_slices_with_length_3);
             }
         }
     }

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -354,15 +354,20 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 expectedSliceCount = 4;
                 slices = searcher.slicesInternal(leaves, expectedSliceCount);
 
-                // 4 slices will be created with 3 leaves in first 2 slices and 2 leaves in other slices
+                // 4 slices will be created with 3 leaves in 2 slices and 2 leaves in other slices
+                // BalancedDocSliceSupplier uses a PQ to assign segments to slices, so the slice assignment is different
+                // than round-robin approach.
+                int num_slices_with_length_2 = 0;
+                int num_slices_with_length_3 = 0;
                 assertEquals(expectedSliceCount, slices.length);
                 for (int i = 0; i < expectedSliceCount; ++i) {
-                    if (i < 2) {
-                        assertEquals(3, slices[i].partitions.length);
-                    } else {
-                        assertEquals(2, slices[i].partitions.length);
-                    }
+                    if (slices[i].partitions.length == 2)
+                        num_slices_with_length_2++;
+                    else if (slices[i].partitions.length == 3)
+                        num_slices_with_length_3++;
                 }
+                assertEquals(2, num_slices_with_length_2);
+                assertEquals(2, num_slices_with_length_3);
             }
         }
     }
@@ -414,15 +419,20 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 int expectedSliceCount = 4;
                 IndexSearcher.LeafSlice[] slices = searcher.slices(leaves);
 
-                // 4 slices will be created with 3 leaves in first 2 slices and 2 leaves in other slices
+                // 4 slices will be created with 3 leaves in 2 slices and 2 leaves in other slices
+                // BalancedDocSliceSupplier uses a PQ to assign segments to slices, so the slice assignment is different
+                // than round-robin approach.
+                int num_slices_with_length_2 = 0;
+                int num_slices_with_length_3 = 0;
                 assertEquals(expectedSliceCount, slices.length);
                 for (int i = 0; i < expectedSliceCount; ++i) {
-                    if (i < 2) {
-                        assertEquals(3, slices[i].partitions.length);
-                    } else {
-                        assertEquals(2, slices[i].partitions.length);
-                    }
+                    if (slices[i].partitions.length == 2)
+                        num_slices_with_length_2++;
+                    else if (slices[i].partitions.length == 3)
+                        num_slices_with_length_3++;
                 }
+                assertEquals(2, num_slices_with_length_2);
+                assertEquals(2, num_slices_with_length_3);
             }
         }
     }

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -400,7 +400,7 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                     searchContext
                 );
                 assertEquals(1, searcher.getSlices().length);
-                
+
                 // Case 1: Verify getSlices returns not null when concurrent segment search is disabled
 
                 // Case 2: Verify the slice count when custom max slice computation is used
@@ -437,11 +437,13 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
 
     public void testSlicesInternalWithScrollContext() throws Exception {
         final List<LeafReaderContext> leaves = getLeaves(10);
-        try (Directory directory = newDirectory();
+        try (
+            Directory directory = newDirectory();
             IndexWriter iw = new IndexWriter(
                 directory,
                 new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
-            );) {
+            );
+        ) {
 
             Document document = new Document();
             document.add(new StringField("field1", "value1", Field.Store.NO));

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -85,7 +85,6 @@ import org.opensearch.search.SearchService;
 import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.test.TestSearchContext;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -362,10 +361,8 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 int num_slices_with_length_3 = 0;
                 assertEquals(expectedSliceCount, slices.length);
                 for (int i = 0; i < expectedSliceCount; ++i) {
-                    if (slices[i].partitions.length == 2)
-                        num_slices_with_length_2++;
-                    else if (slices[i].partitions.length == 3)
-                        num_slices_with_length_3++;
+                    if (slices[i].partitions.length == 2) num_slices_with_length_2++;
+                    else if (slices[i].partitions.length == 3) num_slices_with_length_3++;
                 }
                 assertEquals(2, num_slices_with_length_2);
                 assertEquals(2, num_slices_with_length_3);
@@ -419,6 +416,7 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 when(searchContext.getTargetMaxSliceCount()).thenReturn(4);
                 int expectedSliceCount = 4;
                 IndexSearcher.LeafSlice[] slices = searcher.slices(leaves);
+                when(searchContext.shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch()).thenReturn(true);
 
                 // 4 slices will be created with 3 leaves in 2 slices and 2 leaves in other slices
                 // BalancedDocSliceSupplier uses a PQ to assign segments to slices, so the slice assignment is different
@@ -427,20 +425,22 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 int num_slices_with_length_3 = 0;
                 assertEquals(expectedSliceCount, slices.length);
                 for (int i = 0; i < expectedSliceCount; ++i) {
-                    if (slices[i].partitions.length == 2)
-                        num_slices_with_length_2++;
-                    else if (slices[i].partitions.length == 3)
-                        num_slices_with_length_3++;
+                    if (slices[i].partitions.length == 2) num_slices_with_length_2++;
+                    else if (slices[i].partitions.length == 3) num_slices_with_length_3++;
                 }
                 assertEquals(2, num_slices_with_length_2);
                 assertEquals(2, num_slices_with_length_3);
             }
         }
     }
+
     public void testSlicesInternalWithScrollContext() throws Exception {
         final List<LeafReaderContext> leaves = getLeaves(10);
         try (Directory directory = newDirectory()) {
-            IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
+            IndexWriter iw = new IndexWriter(
+                directory,
+                new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
+            );
 
             Document document = new Document();
             document.add(new StringField("field1", "value1", Field.Store.NO));
@@ -454,6 +454,53 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 when(searchContext.indexShard()).thenReturn(indexShard);
                 when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
                 when(searchContext.scrollContext()).thenReturn(new ScrollContext());
+                when(searchContext.shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch()).thenReturn(true);
+                ContextIndexSearcher searcher = new ContextIndexSearcher(
+                    directoryReader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    true,
+                    null,
+                    searchContext
+                );
+
+                int expectedSliceCount = 4;
+                IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(leaves, expectedSliceCount);
+                assertTrue(searcher.shouldUseMaxTargetSlice());
+                assertEquals(expectedSliceCount, slices.length);
+                for (int i = 0; i < expectedSliceCount; ++i) {
+                    if (i < 2) {
+                        assertEquals(3, slices[i].partitions.length);
+                    } else {
+                        assertEquals(2, slices[i].partitions.length);
+                    }
+                }
+            }
+        }
+    }
+
+    public void test_whenExperimentalSlicingEnabled_thenShouldUseMaxTargetSliceIsFalse() throws Exception {
+        final List<LeafReaderContext> leaves = getLeaves(10);
+        try (Directory directory = newDirectory()) {
+            IndexWriter iw = new IndexWriter(
+                directory,
+                new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
+            );
+
+            Document document = new Document();
+            document.add(new StringField("field1", "value1", Field.Store.NO));
+            document.add(new StringField("field2", "value1", Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+
+            try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
+                SearchContext searchContext = mock(SearchContext.class);
+                IndexShard indexShard = mock(IndexShard.class);
+                when(searchContext.indexShard()).thenReturn(indexShard);
+                when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+                when(searchContext.shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch()).thenReturn(true);
+                // No scroll context setup - defaults to null
 
                 ContextIndexSearcher searcher = new ContextIndexSearcher(
                     directoryReader,
@@ -468,22 +515,18 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 int expectedSliceCount = 4;
                 IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(leaves, expectedSliceCount);
 
-                assertEquals(expectedSliceCount, slices.length);
-                for (int i = 0; i < expectedSliceCount; ++i) {
-                    if (i < 2) {
-                        assertEquals(3, slices[i].partitions.length);
-                    } else {
-                        assertEquals(2, slices[i].partitions.length);
-                    }
-                }
+                assertEquals(false, searcher.shouldUseMaxTargetSlice());
             }
         }
     }
 
-    public void testSlicesInternalWithoutScrollContext() throws Exception {
+    public void test_whenExperimentalSlicingDisabled_thenShouldUseMaxTargetSliceIsTrue() throws Exception {
         final List<LeafReaderContext> leaves = getLeaves(10);
         try (Directory directory = newDirectory()) {
-            IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
+            IndexWriter iw = new IndexWriter(
+                directory,
+                new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
+            );
 
             Document document = new Document();
             document.add(new StringField("field1", "value1", Field.Store.NO));
@@ -496,6 +539,47 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 IndexShard indexShard = mock(IndexShard.class);
                 when(searchContext.indexShard()).thenReturn(indexShard);
                 when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+                when(searchContext.shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch()).thenReturn(false);
+                // No scroll context setup - defaults to null
+
+                ContextIndexSearcher searcher = new ContextIndexSearcher(
+                    directoryReader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    true,
+                    null,
+                    searchContext
+                );
+
+                int expectedSliceCount = 4;
+                IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(leaves, expectedSliceCount);
+
+                assertEquals(true, searcher.shouldUseMaxTargetSlice());
+            }
+        }
+    }
+
+    public void testSlicesInternalWithoutScrollContext() throws Exception {
+        final List<LeafReaderContext> leaves = getLeaves(10);
+        try (Directory directory = newDirectory()) {
+            IndexWriter iw = new IndexWriter(
+                directory,
+                new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
+            );
+
+            Document document = new Document();
+            document.add(new StringField("field1", "value1", Field.Store.NO));
+            document.add(new StringField("field2", "value1", Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+
+            try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
+                SearchContext searchContext = mock(SearchContext.class);
+                IndexShard indexShard = mock(IndexShard.class);
+                when(searchContext.indexShard()).thenReturn(indexShard);
+                when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+                when(searchContext.shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch()).thenReturn(true);
                 // No scroll context setup - defaults to null
 
                 ContextIndexSearcher searcher = new ContextIndexSearcher(
@@ -516,10 +600,57 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 int num_slices_with_length_3 = 0;
                 assertEquals(expectedSliceCount, slices.length);
                 for (int i = 0; i < expectedSliceCount; ++i) {
-                    if (slices[i].partitions.length == 2)
-                        num_slices_with_length_2++;
-                    else if (slices[i].partitions.length == 3)
-                        num_slices_with_length_3++;
+                    if (slices[i].partitions.length == 2) num_slices_with_length_2++;
+                    else if (slices[i].partitions.length == 3) num_slices_with_length_3++;
+                }
+                assertEquals(2, num_slices_with_length_2);
+                assertEquals(2, num_slices_with_length_3);
+            }
+        }
+    }
+
+    public void testSlicesInternalWithConfigChanges() throws Exception {
+        final List<LeafReaderContext> leaves = getLeaves(10);
+        try (Directory directory = newDirectory()) {
+            IndexWriter iw = new IndexWriter(
+                directory,
+                new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
+            );
+
+            Document document = new Document();
+            document.add(new StringField("field1", "value1", Field.Store.NO));
+            document.add(new StringField("field2", "value1", Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+
+            try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
+                SearchContext searchContext = mock(SearchContext.class);
+                IndexShard indexShard = mock(IndexShard.class);
+                when(searchContext.indexShard()).thenReturn(indexShard);
+                when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+                when(searchContext.shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch()).thenReturn(true);
+                // No scroll context setup - defaults to null
+
+                ContextIndexSearcher searcher = new ContextIndexSearcher(
+                    directoryReader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    true,
+                    null,
+                    searchContext
+                );
+
+                int expectedSliceCount = 4;
+                IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(leaves, expectedSliceCount);
+
+                // BalancedDocsSliceSupplier uses PQ so ordering is not deterministic
+                int num_slices_with_length_2 = 0;
+                int num_slices_with_length_3 = 0;
+                assertEquals(expectedSliceCount, slices.length);
+                for (int i = 0; i < expectedSliceCount; ++i) {
+                    if (slices[i].partitions.length == 2) num_slices_with_length_2++;
+                    else if (slices[i].partitions.length == 3) num_slices_with_length_3++;
                 }
                 assertEquals(2, num_slices_with_length_2);
                 assertEquals(2, num_slices_with_length_3);

--- a/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/opensearch/search/internal/ContextIndexSearcherTests.java
@@ -85,6 +85,7 @@ import org.opensearch.search.SearchService;
 import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.TestSearchContext;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -422,6 +423,95 @@ public class ContextIndexSearcherTests extends OpenSearchTestCase {
                 // 4 slices will be created with 3 leaves in 2 slices and 2 leaves in other slices
                 // BalancedDocSliceSupplier uses a PQ to assign segments to slices, so the slice assignment is different
                 // than round-robin approach.
+                int num_slices_with_length_2 = 0;
+                int num_slices_with_length_3 = 0;
+                assertEquals(expectedSliceCount, slices.length);
+                for (int i = 0; i < expectedSliceCount; ++i) {
+                    if (slices[i].partitions.length == 2)
+                        num_slices_with_length_2++;
+                    else if (slices[i].partitions.length == 3)
+                        num_slices_with_length_3++;
+                }
+                assertEquals(2, num_slices_with_length_2);
+                assertEquals(2, num_slices_with_length_3);
+            }
+        }
+    }
+    public void testSlicesInternalWithScrollContext() throws Exception {
+        final List<LeafReaderContext> leaves = getLeaves(10);
+        try (Directory directory = newDirectory()) {
+            IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
+
+            Document document = new Document();
+            document.add(new StringField("field1", "value1", Field.Store.NO));
+            document.add(new StringField("field2", "value1", Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+
+            try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
+                SearchContext searchContext = mock(SearchContext.class);
+                IndexShard indexShard = mock(IndexShard.class);
+                when(searchContext.indexShard()).thenReturn(indexShard);
+                when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+                when(searchContext.scrollContext()).thenReturn(new ScrollContext());
+
+                ContextIndexSearcher searcher = new ContextIndexSearcher(
+                    directoryReader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    true,
+                    null,
+                    searchContext
+                );
+
+                int expectedSliceCount = 4;
+                IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(leaves, expectedSliceCount);
+
+                assertEquals(expectedSliceCount, slices.length);
+                for (int i = 0; i < expectedSliceCount; ++i) {
+                    if (i < 2) {
+                        assertEquals(3, slices[i].partitions.length);
+                    } else {
+                        assertEquals(2, slices[i].partitions.length);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testSlicesInternalWithoutScrollContext() throws Exception {
+        final List<LeafReaderContext> leaves = getLeaves(10);
+        try (Directory directory = newDirectory()) {
+            IndexWriter iw = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE));
+
+            Document document = new Document();
+            document.add(new StringField("field1", "value1", Field.Store.NO));
+            document.add(new StringField("field2", "value1", Field.Store.NO));
+            iw.addDocument(document);
+            iw.commit();
+
+            try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
+                SearchContext searchContext = mock(SearchContext.class);
+                IndexShard indexShard = mock(IndexShard.class);
+                when(searchContext.indexShard()).thenReturn(indexShard);
+                when(searchContext.bucketCollectorProcessor()).thenReturn(SearchContext.NO_OP_BUCKET_COLLECTOR_PROCESSOR);
+                // No scroll context setup - defaults to null
+
+                ContextIndexSearcher searcher = new ContextIndexSearcher(
+                    directoryReader,
+                    IndexSearcher.getDefaultSimilarity(),
+                    IndexSearcher.getDefaultQueryCache(),
+                    IndexSearcher.getDefaultQueryCachingPolicy(),
+                    true,
+                    null,
+                    searchContext
+                );
+
+                int expectedSliceCount = 4;
+                IndexSearcher.LeafSlice[] slices = searcher.slicesInternal(leaves, expectedSliceCount);
+
+                // BalancedDocsSliceSupplier uses PQ so ordering is not deterministic
                 int num_slices_with_length_2 = 0;
                 int num_slices_with_length_3 = 0;
                 assertEquals(expectedSliceCount, slices.length);

--- a/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
+++ b/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
@@ -65,7 +65,7 @@ public class IndexReaderUtils {
                 final String fieldValue = "value" + i;
                 for (int j = 0; j < docCounts[i]; j++) {
                     Document document = new Document();
-                    document.add(new StringField("field1:" +j , fieldValue, Field.Store.NO));
+                    document.add(new StringField("field1:" + j, fieldValue, Field.Store.NO));
                     document.add(new StringField("field2:" + j, fieldValue, Field.Store.NO));
                     iw.addDocument(document);
                 }

--- a/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
+++ b/server/src/test/java/org/opensearch/search/internal/IndexReaderUtils.java
@@ -52,4 +52,29 @@ public class IndexReaderUtils {
             }
         }
     }
+
+    public static List<LeafReaderContext> getLeavesWithDocCounts(int[] docCounts) throws Exception {
+        try (
+            final Directory directory = newDirectory();
+            final IndexWriter iw = new IndexWriter(
+                directory,
+                new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(NoMergePolicy.INSTANCE)
+            )
+        ) {
+            for (int i = 0; i < docCounts.length; ++i) {
+                final String fieldValue = "value" + i;
+                for (int j = 0; j < docCounts[i]; j++) {
+                    Document document = new Document();
+                    document.add(new StringField("field1:" +j , fieldValue, Field.Store.NO));
+                    document.add(new StringField("field2:" + j, fieldValue, Field.Store.NO));
+                    iw.addDocument(document);
+                }
+                iw.commit();
+            }
+            try (DirectoryReader directoryReader = DirectoryReader.open(directory)) {
+                List<LeafReaderContext> leaves = directoryReader.leaves();
+                return leaves;
+            }
+        }
+    }
 }

--- a/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
@@ -708,7 +708,7 @@ public class TestSearchContext extends SearchContext {
 
     @Override
     public boolean shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch() {
-        assert concurrentSegmentSearchEnabled == true : "Please use concurrent search before fetching maxSliceCount";
+        assert concurrentSegmentSearchEnabled == true : "Please use concurrent search before enabling experimental balanced slicing";
         return shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch;
     }
 

--- a/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/opensearch/test/TestSearchContext.java
@@ -122,6 +122,7 @@ public class TestSearchContext extends SearchContext {
     protected boolean concurrentSegmentSearchEnabled;
     private BucketCollectorProcessor bucketCollectorProcessor = NO_OP_BUCKET_COLLECTOR_PROCESSOR;
     private int maxSliceCount;
+    private boolean shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch;
 
     /**
      * Sets the concurrent segment search enabled field
@@ -175,6 +176,7 @@ public class TestSearchContext extends SearchContext {
         this.concurrentSegmentSearchEnabled = searcher != null; /* executor is always set */
         this.maxSliceCount = randomIntBetween(0, 2);
         this.scrollContext = scrollContext;
+        this.shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch = false;
     }
 
     public void setSearcher(ContextIndexSearcher searcher) {
@@ -702,6 +704,12 @@ public class TestSearchContext extends SearchContext {
     public int getTargetMaxSliceCount() {
         assert concurrentSegmentSearchEnabled == true : "Please use concurrent search before fetching maxSliceCount";
         return maxSliceCount;
+    }
+
+    @Override
+    public boolean shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch() {
+        assert concurrentSegmentSearchEnabled == true : "Please use concurrent search before fetching maxSliceCount";
+        return shouldUseExperimentalBalancedSlicingConcurrentSegmentSearch;
     }
 
     @Override


### PR DESCRIPTION
Operation | Normal Case | Resource Constrained
----------|------------|--------------------
multi_terms-keyword | X |
composite-date_histogram-daily | X |
scroll | X |
term | X |
query-string-on-message-filtered | X |
range-agg-1 | X |
range-agg-2 | X | X
cardinality-agg-low | X | X
date_histogram_minute_agg | X |
keyword-terms | X | X
keyword-terms-low-cardinality | X | X
range | X |
sort_numeric_desc | X | X
asc_sort_timestamp | | X
asc_sort_with_after_timestamp | | X
asc_sort_timestamp_can_match_shortcut | | X
asc_sort_timestamp_no_can_match_shortcut | | X
composite-terms | | X
composite_terms-keyword | | X
sort_keyword_can_match_shortcut | | X
sort_numeric_asc | | X
sort_numeric_desc_with_match | | X
sort_numeric_asc_with_match | | X
range_field_conjunction_small_range_big_term_query | | X


<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/finnrobl/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/finnrobl/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{font-size:10.0pt;
	font-family:"Arial Unicode MS", sans-serif;
	mso-font-charset:0;}
.xl64
	{mso-number-format:Scientific;}
.xl65
	{mso-number-format:Percent;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">


Metric | Task | RR Value | BDSS value | PCT Difference
-- | -- | -- | -- | --
Min Throughput | index-append | 21435.2 | 20597.5 | -3.91%
Mean Throughput | index-append | 23196.2 | 22475.8 | -3.11%
Median Throughput | index-append | 23236.1 | 22326.2 | -3.92%
Max Throughput | index-append | 24101.4 | 23438 | -2.75%
50th percentile latency | index-append | 150.239 | 153.666 | 2.28%
90th percentile latency | index-append | 221.337 | 226.017 | 2.11%
99th percentile latency | index-append | 435.739 | 453.764 | 4.14%
99.9th percentile latency | index-append | 2388.5 | 2576.7 | 7.88%
99.99th percentile latency | index-append | 2915.3 | 3156.16 | 8.26%
100th percentile latency | index-append | 3212.1 | 3622.1 | 12.76%
50th percentile service time | index-append | 150.239 | 153.666 | 2.28%
90th percentile service time | index-append | 221.337 | 226.017 | 2.11%
99th percentile service time | index-append | 435.739 | 453.764 | 4.14%
99.9th percentile service time | index-append | 2388.5 | 2576.7 | 7.88%
99.99th percentile service   time | index-append | 2915.3 | 3156.16 | 8.26%
100th percentile service time | index-append | 3212.1 | 3622.1 | 12.76%
error rate | index-append | 0 | 0 | 0.00%
Min Throughput | wait-until-merges-finish | 0.03 | 0.02 | -33.33%
Mean Throughput | wait-until-merges-finish | 0.03 | 0.02 | -33.33%
Median Throughput | wait-until-merges-finish | 0.03 | 0.02 | -33.33%
Max Throughput | wait-until-merges-finish | 0.03 | 0.02 | -33.33%
100th percentile latency | wait-until-merges-finish | 34858.8 | 43977.9 | 26.16%
100th percentile service time | wait-until-merges-finish | 34858.8 | 43977.9 | 26.16%
error rate | wait-until-merges-finish | 0 | 0 | 0.00%
Min Throughput | default | 2.01 | 2.01 | 0.00%
Mean Throughput | default | 2.01 | 2.01 | 0.00%
Median Throughput | default | 2.01 | 2.01 | 0.00%
Max Throughput | default | 2.01 | 2.01 | 0.00%
50th percentile latency | default | 6.83691 | 6.99958 | 2.38%
90th percentile latency | default | 7.40082 | 7.46212 | 0.83%
99th percentile latency | default | 7.85034 | 7.78354 | -0.85%
100th percentile latency | default | 8.52905 | 8.02909 | -5.86%
50th percentile service time | default | 5.5046 | 5.75858 | 4.61%
90th percentile service time | default | 5.99142 | 6.08313 | 1.53%
99th percentile service time | default | 6.84203 | 6.66118 | -2.64%
100th percentile service time | default | 7.15275 | 6.80843 | -4.81%
error rate | default | 0 | 0 | 0.00%
Min Throughput | desc_sort_timestamp | 2.01 | 2.01 | 0.00%
Mean Throughput | desc_sort_timestamp | 2.01 | 2.01 | 0.00%
Median Throughput | desc_sort_timestamp | 2.01 | 2.01 | 0.00%
Max Throughput | desc_sort_timestamp | 2.01 | 2.01 | 0.00%
50th percentile latency | desc_sort_timestamp | 8.55013 | 7.70418 | -9.89%
90th percentile latency | desc_sort_timestamp | 9.00965 | 8.32149 | -7.64%
99th percentile latency | desc_sort_timestamp | 10.2655 | 9.53418 | -7.12%
100th percentile latency | desc_sort_timestamp | 12.3057 | 9.90115 | -19.54%
50th percentile service time | desc_sort_timestamp | 7.25478 | 6.38886 | -11.94%
90th percentile service time | desc_sort_timestamp | 7.53907 | 6.90453 | -8.42%
99th percentile service time | desc_sort_timestamp | 8.55977 | 8.24639 | -3.66%
100th percentile service time | desc_sort_timestamp | 10.8762 | 8.98668 | -17.37%
error rate | desc_sort_timestamp | 0 | 0 | 0.00%
Min Throughput | asc_sort_timestamp | 2 | 2 | 0.00%
Mean Throughput | asc_sort_timestamp | 2 | 2 | 0.00%
Median Throughput | asc_sort_timestamp | 2 | 2 | 0.00%
Max Throughput | asc_sort_timestamp | 2 | 2.01 | 0.50%
50th percentile latency | asc_sort_timestamp | 53.3863 | 59.1885 | 10.87%
90th percentile latency | asc_sort_timestamp | 54.1035 | 60.253 | 11.37%
99th percentile latency | asc_sort_timestamp | 54.8322 | 66.1622 | 20.66%
100th percentile latency | asc_sort_timestamp | 58.4793 | 66.2406 | 13.27%
50th percentile service time | asc_sort_timestamp | 52.1142 | 58.026 | 11.34%
90th percentile service time | asc_sort_timestamp | 52.7687 | 58.9996 | 11.81%
99th percentile service time | asc_sort_timestamp | 53.4769 | 65.0576 | 21.66%
100th percentile service time | asc_sort_timestamp | 56.954 | 65.3049 | 14.66%
error rate | asc_sort_timestamp | 0 | 0 | 0.00%
Min Throughput | desc_sort_with_after_timestamp | 2.01 | 2.01 | 0.00%
Mean Throughput | desc_sort_with_after_timestamp | 2.01 | 2.01 | 0.00%
Median Throughput | desc_sort_with_after_timestamp | 2.01 | 2.01 | 0.00%
Max Throughput | desc_sort_with_after_timestamp | 2.01 | 2.01 | 0.00%
50th percentile latency | desc_sort_with_after_timestamp | 7.321 | 7.1814 | -1.91%
90th percentile latency | desc_sort_with_after_timestamp | 7.72971 | 7.67058 | -0.76%
99th percentile latency | desc_sort_with_after_timestamp | 8.22336 | 8.05827 | -2.01%
100th percentile latency | desc_sort_with_after_timestamp | 9.48023 | 8.1049 | -14.51%
50th percentile service time | desc_sort_with_after_timestamp | 6.02405 | 6.0605 | 0.61%
90th percentile service time | desc_sort_with_after_timestamp | 6.16388 | 6.28648 | 1.99%
99th percentile service time | desc_sort_with_after_timestamp | 6.97369 | 6.73745 | -3.39%
100th percentile service time | desc_sort_with_after_timestamp | 7.93142 | 6.98885 | -11.88%
error rate | desc_sort_with_after_timestamp | 0 | 0 | 0.00%
Min Throughput | asc_sort_with_after_timestamp | 2 | 2.01 | 0.50%
Mean Throughput | asc_sort_with_after_timestamp | 2.01 | 2.01 | 0.00%
Median Throughput | asc_sort_with_after_timestamp | 2.01 | 2.01 | 0.00%
Max Throughput | asc_sort_with_after_timestamp | 2.01 | 2.01 | 0.00%
50th percentile latency | asc_sort_with_after_timestamp | 20.924 | 22.9519 | 9.69%
90th percentile latency | asc_sort_with_after_timestamp | 21.6415 | 23.5329 | 8.74%
99th percentile latency | asc_sort_with_after_timestamp | 23.3913 | 24.4759 | 4.64%
100th percentile latency | asc_sort_with_after_timestamp | 28.019 | 24.5559 | -12.36%
50th percentile service time | asc_sort_with_after_timestamp | 19.0664 | 20.6969 | 8.55%
90th percentile service time | asc_sort_with_after_timestamp | 19.334 | 21.2632 | 9.98%
99th percentile service time | asc_sort_with_after_timestamp | 20.9246 | 22.2495 | 6.33%
100th percentile service time | asc_sort_with_after_timestamp | 25.7849 | 22.3906 | -13.16%
error rate | asc_sort_with_after_timestamp | 0 | 0 | 0.00%
Min Throughput | desc_sort_timestamp_can_match_shortcut | 2.01 | 2.01 | 0.00%
Mean Throughput | desc_sort_timestamp_can_match_shortcut | 2.01 | 2.01 | 0.00%
Median Throughput | desc_sort_timestamp_can_match_shortcut | 2.01 | 2.01 | 0.00%
Max Throughput | desc_sort_timestamp_can_match_shortcut | 2.01 | 2.01 | 0.00%
50th percentile latency | desc_sort_timestamp_can_match_shortcut | 8.37656 | 7.60418 | -9.22%
90th percentile latency | desc_sort_timestamp_can_match_shortcut | 8.77441 | 8.09463 | -7.75%
99th percentile latency | desc_sort_timestamp_can_match_shortcut | 10.0531 | 8.93899 | -11.08%
100th percentile latency | desc_sort_timestamp_can_match_shortcut | 10.3253 | 9.07771 | -12.08%
50th percentile service time | desc_sort_timestamp_can_match_shortcut | 7.03687 | 6.39258 | -9.16%
90th percentile service time | desc_sort_timestamp_can_match_shortcut | 7.28507 | 6.59825 | -9.43%
99th percentile service time | desc_sort_timestamp_can_match_shortcut | 9.07784 | 7.39162 | -18.58%
100th percentile service time | desc_sort_timestamp_can_match_shortcut | 9.08966 | 7.80359 | -14.15%
error rate | desc_sort_timestamp_can_match_shortcut | 0 | 0 | 0.00%
Min Throughput | desc_sort_timestamp_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
Mean Throughput | desc_sort_timestamp_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
Median Throughput | desc_sort_timestamp_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
Max Throughput | desc_sort_timestamp_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
50th percentile latency | desc_sort_timestamp_no_can_match_shortcut | 7.7995 | 7.4976 | -3.87%
90th percentile latency | desc_sort_timestamp_no_can_match_shortcut | 8.2047 | 7.91917 | -3.48%
99th percentile latency | desc_sort_timestamp_no_can_match_shortcut | 8.33786 | 8.16103 | -2.12%
100th percentile latency | desc_sort_timestamp_no_can_match_shortcut | 8.35523 | 8.43132 | 0.91%
50th percentile service time | desc_sort_timestamp_no_can_match_shortcut | 6.50117 | 6.20729 | -4.52%
90th percentile service time | desc_sort_timestamp_no_can_match_shortcut | 6.62583 | 6.37984 | -3.71%
99th percentile service time | desc_sort_timestamp_no_can_match_shortcut | 6.71619 | 6.6102 | -1.58%
100th percentile service time | desc_sort_timestamp_no_can_match_shortcut | 6.83512 | 7.13257 | 4.35%
error rate | desc_sort_timestamp_no_can_match_shortcut | 0 | 0 | 0.00%
Min Throughput | asc_sort_timestamp_can_match_shortcut | 2.01 | 2 | -0.50%
Mean Throughput | asc_sort_timestamp_can_match_shortcut | 2.01 | 2 | -0.50%
Median Throughput | asc_sort_timestamp_can_match_shortcut | 2.01 | 2 | -0.50%
Max Throughput | asc_sort_timestamp_can_match_shortcut | 2.01 | 2 | -0.50%
50th percentile latency | asc_sort_timestamp_can_match_shortcut | 21.5207 | 22.7762 | 5.83%
90th percentile latency | asc_sort_timestamp_can_match_shortcut | 21.9255 | 23.1784 | 5.71%
99th percentile latency | asc_sort_timestamp_can_match_shortcut | 22.0524 | 24.4988 | 11.09%
100th percentile latency | asc_sort_timestamp_can_match_shortcut | 22.1372 | 32.6833 | 47.64%
50th percentile service time | asc_sort_timestamp_can_match_shortcut | 19.325 | 20.5547 | 6.36%
90th percentile service time | asc_sort_timestamp_can_match_shortcut | 19.4636 | 20.7945 | 6.84%
99th percentile service time | asc_sort_timestamp_can_match_shortcut | 19.5958 | 22.9521 | 17.13%
100th percentile service time | asc_sort_timestamp_can_match_shortcut | 19.6169 | 30.4177 | 55.06%
error rate | asc_sort_timestamp_can_match_shortcut | 0 | 0 | 0.00%
Min Throughput | asc_sort_timestamp_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
Mean Throughput | asc_sort_timestamp_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
Median Throughput | asc_sort_timestamp_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
Max Throughput | asc_sort_timestamp_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
50th percentile latency | asc_sort_timestamp_no_can_match_shortcut | 20.1617 | 22.7245 | 12.71%
90th percentile latency | asc_sort_timestamp_no_can_match_shortcut | 20.7146 | 23.1849 | 11.93%
99th percentile latency | asc_sort_timestamp_no_can_match_shortcut | 21.5493 | 23.6233 | 9.62%
100th percentile latency | asc_sort_timestamp_no_can_match_shortcut | 23.334 | 25.2101 | 8.04%
50th percentile service time | asc_sort_timestamp_no_can_match_shortcut | 18.8927 | 20.4127 | 8.05%
90th percentile service time | asc_sort_timestamp_no_can_match_shortcut | 19.1565 | 20.6485 | 7.79%
99th percentile service time | asc_sort_timestamp_no_can_match_shortcut | 19.4418 | 21.6171 | 11.19%
100th percentile service time | asc_sort_timestamp_no_can_match_shortcut | 22.409 | 23.1536 | 3.32%
error rate | asc_sort_timestamp_no_can_match_shortcut | 0 | 0 | 0.00%
Min Throughput | term | 2.01 | 2.01 | 0.00%
Mean Throughput | term | 2.01 | 2.01 | 0.00%
Median Throughput | term | 2.01 | 2.01 | 0.00%
Max Throughput | term | 2.01 | 2.01 | 0.00%
50th percentile latency | term | 4.30208 | 4.22167 | -1.87%
90th percentile latency | term | 4.81094 | 4.76164 | -1.02%
99th percentile latency | term | 5.13662 | 5.74874 | 11.92%
100th percentile latency | term | 17.7424 | 6.88941 | -61.17%
50th percentile service time | term | 3.14208 | 2.98542 | -4.99%
90th percentile service time | term | 3.252 | 3.17064 | -2.50%
99th percentile service time | term | 3.6623 | 4.10164 | 12.00%
100th percentile service time | term | 16.6516 | 5.16519 | -68.98%
error rate | term | 0 | 0 | 0.00%
Min Throughput | multi_terms-keyword | 1.99 | 1.99 | 0.00%
Mean Throughput | multi_terms-keyword | 1.99 | 1.99 | 0.00%
Median Throughput | multi_terms-keyword | 1.99 | 1.99 | 0.00%
Max Throughput | multi_terms-keyword | 1.99 | 1.99 | 0.00%
50th percentile latency | multi_terms-keyword | 467.948 | 436.706 | -6.68%
90th percentile latency | multi_terms-keyword | 511.052 | 440.412 | -13.82%
99th percentile latency | multi_terms-keyword | 551.622 | 493.274 | -10.58%
100th percentile latency | multi_terms-keyword | 556.516 | 498.242 | -10.47%
50th percentile service time | multi_terms-keyword | 462.895 | 436.073 | -5.79%
90th percentile service time | multi_terms-keyword | 507.072 | 439.96 | -13.24%
99th percentile service time | multi_terms-keyword | 532.395 | 492.387 | -7.51%
100th percentile service time | multi_terms-keyword | 550.663 | 497.813 | -9.60%
error rate | multi_terms-keyword | 0 | 0 | 0.00%
Min Throughput | keyword-terms | 2 | 2 | 0.00%
Mean Throughput | keyword-terms | 2 | 2 | 0.00%
Median Throughput | keyword-terms | 2 | 2 | 0.00%
Max Throughput | keyword-terms | 2.01 | 2.01 | 0.00%
50th percentile latency | keyword-terms | 51.9136 | 54.1415 | 4.29%
90th percentile latency | keyword-terms | 53.4353 | 60.6345 | 13.47%
99th percentile latency | keyword-terms | 55.4517 | 64.7282 | 16.73%
100th percentile latency | keyword-terms | 57.2056 | 69.8779 | 22.15%
50th percentile service time | keyword-terms | 50.9817 | 52.9376 | 3.84%
90th percentile service time | keyword-terms | 52.2121 | 59.0865 | 13.17%
99th percentile service time | keyword-terms | 53.8357 | 63.2273 | 17.44%
100th percentile service time | keyword-terms | 56.7442 | 69.0261 | 21.64%
error rate | keyword-terms | 0 | 0 | 0.00%
Min Throughput | keyword-terms-low-cardinality | 2.01 | 2.01 | 0.00%
Mean Throughput | keyword-terms-low-cardinality | 2.01 | 2.01 | 0.00%
Median Throughput | keyword-terms-low-cardinality | 2.01 | 2.01 | 0.00%
Max Throughput | keyword-terms-low-cardinality | 2.01 | 2.01 | 0.00%
50th percentile latency | keyword-terms-low-cardinality | 30.714 | 36.5876 | 19.12%
90th percentile latency | keyword-terms-low-cardinality | 31.5837 | 43.5843 | 38.00%
99th percentile latency | keyword-terms-low-cardinality | 34.892 | 47.2397 | 35.39%
100th percentile latency | keyword-terms-low-cardinality | 37.5206 | 48.7713 | 29.99%
50th percentile service time | keyword-terms-low-cardinality | 29.4669 | 35.3982 | 20.13%
90th percentile service time | keyword-terms-low-cardinality | 30.2454 | 42.3229 | 39.93%
99th percentile service time | keyword-terms-low-cardinality | 34.1553 | 46.5819 | 36.38%
100th percentile service time | keyword-terms-low-cardinality | 36.3002 | 47.5642 | 31.03%
error rate | keyword-terms-low-cardinality | 0 | 0 | 0.00%
Min Throughput | composite-terms | 2 | 2 | 0.00%
Mean Throughput | composite-terms | 2 | 2 | 0.00%
Median Throughput | composite-terms | 2 | 2 | 0.00%
Max Throughput | composite-terms | 2 | 2 | 0.00%
50th percentile latency | composite-terms | 130.611 | 143.858 | 10.14%
90th percentile latency | composite-terms | 138.825 | 149.769 | 7.88%
99th percentile latency | composite-terms | 159.102 | 156.648 | -1.54%
100th percentile latency | composite-terms | 228.998 | 157.611 | -31.17%
50th percentile service time | composite-terms | 129.451 | 142.338 | 9.96%
90th percentile service time | composite-terms | 137.909 | 148.776 | 7.88%
99th percentile service time | composite-terms | 157.83 | 155.35 | -1.57%
100th percentile service time | composite-terms | 227.528 | 156.387 | -31.27%
error rate | composite-terms | 0 | 0 | 0.00%
Min Throughput | composite_terms-keyword | 2 | 2 | 0.00%
Mean Throughput | composite_terms-keyword | 2 | 2 | 0.00%
Median Throughput | composite_terms-keyword | 2 | 2 | 0.00%
Max Throughput | composite_terms-keyword | 2 | 2 | 0.00%
50th percentile latency | composite_terms-keyword | 255.894 | 282.941 | 10.57%
90th percentile latency | composite_terms-keyword | 269.206 | 292.131 | 8.52%
99th percentile latency | composite_terms-keyword | 273.745 | 306.041 | 11.80%
100th percentile latency | composite_terms-keyword | 273.92 | 319.731 | 16.72%
50th percentile service time | composite_terms-keyword | 254.692 | 281.829 | 10.65%
90th percentile service time | composite_terms-keyword | 268.421 | 290.742 | 8.32%
99th percentile service time | composite_terms-keyword | 272.91 | 304.909 | 11.73%
100th percentile service time | composite_terms-keyword | 273.082 | 318.38 | 16.59%
error rate | composite_terms-keyword | 0 | 0 | 0.00%
Min Throughput | composite-date_histogram-daily | 2.01 | 2.01 | 0.00%
Mean Throughput | composite-date_histogram-daily | 2.01 | 2.01 | 0.00%
Median Throughput | composite-date_histogram-daily | 2.01 | 2.01 | 0.00%
Max Throughput | composite-date_histogram-daily | 2.01 | 2.01 | 0.00%
50th percentile latency | composite-date_histogram-daily | 6.26215 | 6.25692 | -0.08%
90th percentile latency | composite-date_histogram-daily | 6.68784 | 6.73742 | 0.74%
99th percentile latency | composite-date_histogram-daily | 7.67581 | 6.97425 | -9.14%
100th percentile latency | composite-date_histogram-daily | 8.54004 | 7.07225 | -17.19%
50th percentile service time | composite-date_histogram-daily | 4.90788 | 4.99756 | 1.83%
90th percentile service time | composite-date_histogram-daily | 5.15642 | 5.28369 | 2.47%
99th percentile service time | composite-date_histogram-daily | 6.01902 | 5.44088 | -9.61%
100th percentile service time | composite-date_histogram-daily | 7.23145 | 5.80049 | -19.79%
error rate | composite-date_histogram-daily | 0 | 0 | 0.00%
Min Throughput | range | 2 | 2.01 | 0.50%
Mean Throughput | range | 2.01 | 2.01 | 0.00%
Median Throughput | range | 2.01 | 2.01 | 0.00%
Max Throughput | range | 2.01 | 2.01 | 0.00%
50th percentile latency | range | 48.5329 | 46.359 | -4.48%
90th percentile latency | range | 53.7752 | 53.5608 | -0.40%
99th percentile latency | range | 59.9781 | 57.2966 | -4.47%
100th percentile latency | range | 65.7916 | 60.121 | -8.62%
50th percentile service time | range | 47.2336 | 45.2491 | -4.20%
90th percentile service time | range | 52.6087 | 52.3004 | -0.59%
99th percentile service time | range | 59.2734 | 55.8256 | -5.82%
100th percentile service time | range | 64.8949 | 59.0181 | -9.06%
error rate | range | 0 | 0 | 0.00%
Min Throughput | range-numeric | 2.01 | 2.01 | 0.00%
Mean Throughput | range-numeric | 2.01 | 2.01 | 0.00%
Median Throughput | range-numeric | 2.01 | 2.01 | 0.00%
Max Throughput | range-numeric | 2.01 | 2.01 | 0.00%
50th percentile latency | range-numeric | 4.43584 | 3.85464 | -13.10%
90th percentile latency | range-numeric | 4.82917 | 4.29234 | -11.12%
99th percentile latency | range-numeric | 5.02206 | 4.51785 | -10.04%
100th percentile latency | range-numeric | 5.11844 | 4.59388 | -10.25%
50th percentile service time | range-numeric | 3.19115 | 2.62315 | -17.80%
90th percentile service time | range-numeric | 3.30519 | 2.77552 | -16.03%
99th percentile service time | range-numeric | 3.42452 | 2.89615 | -15.43%
100th percentile service time | range-numeric | 3.45001 | 2.89756 | -16.01%
error rate | range-numeric | 0 | 0 | 0.00%
Min Throughput | keyword-in-range | 2 | 2 | 0.00%
Mean Throughput | keyword-in-range | 2 | 2 | 0.00%
Median Throughput | keyword-in-range | 2 | 2 | 0.00%
Max Throughput | keyword-in-range | 2 | 2 | 0.00%
50th percentile latency | keyword-in-range | 148.397 | 141.916 | -4.37%
90th percentile latency | keyword-in-range | 161.359 | 147.951 | -8.31%
99th percentile latency | keyword-in-range | 176.359 | 156.14 | -11.46%
100th percentile latency | keyword-in-range | 180.171 | 159.093 | -11.70%
50th percentile service time | keyword-in-range | 146.739 | 141.061 | -3.87%
90th percentile service time | keyword-in-range | 160.402 | 146.852 | -8.45%
99th percentile service time | keyword-in-range | 175.649 | 155.071 | -11.72%
100th percentile service time | keyword-in-range | 179.165 | 158.413 | -11.58%
error rate | keyword-in-range | 0 | 0 | 0.00%
Min Throughput | date_histogram_hourly_agg | 2.01 | 2.01 | 0.00%
Mean Throughput | date_histogram_hourly_agg | 2.01 | 2.01 | 0.00%
Median Throughput | date_histogram_hourly_agg | 2.01 | 2.01 | 0.00%
Max Throughput | date_histogram_hourly_agg | 2.01 | 2.01 | 0.00%
50th percentile latency | date_histogram_hourly_agg | 8.87146 | 8.80801 | -0.72%
90th percentile latency | date_histogram_hourly_agg | 9.40246 | 9.20819 | -2.07%
99th percentile latency | date_histogram_hourly_agg | 10.5109 | 10.0013 | -4.85%
100th percentile latency | date_histogram_hourly_agg | 10.6649 | 10.3432 | -3.02%
50th percentile service time | date_histogram_hourly_agg | 7.60127 | 7.54355 | -0.76%
90th percentile service time | date_histogram_hourly_agg | 7.96258 | 7.81488 | -1.85%
99th percentile service time | date_histogram_hourly_agg | 8.906 | 8.9844 | 0.88%
100th percentile service time | date_histogram_hourly_agg | 9.76089 | 9.26521 | -5.08%
error rate | date_histogram_hourly_agg | 0 | 0 | 0.00%
Min Throughput | date_histogram_minute_agg | 2.01 | 2.01 | 0.00%
Mean Throughput | date_histogram_minute_agg | 2.01 | 2.01 | 0.00%
Median Throughput | date_histogram_minute_agg | 2.01 | 2.01 | 0.00%
Max Throughput | date_histogram_minute_agg | 2.01 | 2.01 | 0.00%
50th percentile latency | date_histogram_minute_agg | 39.5181 | 35.6183 | -9.87%
90th percentile latency | date_histogram_minute_agg | 42.8326 | 37.7147 | -11.95%
99th percentile latency | date_histogram_minute_agg | 45.5866 | 39.1879 | -14.04%
100th percentile latency | date_histogram_minute_agg | 46.969 | 43.7682 | -6.81%
50th percentile service time | date_histogram_minute_agg | 38.3783 | 34.2801 | -10.68%
90th percentile service time | date_histogram_minute_agg | 41.5638 | 36.2759 | -12.72%
99th percentile service time | date_histogram_minute_agg | 44.0882 | 38.2916 | -13.15%
100th percentile service time | date_histogram_minute_agg | 45.3847 | 42.3005 | -6.80%
error rate | date_histogram_minute_agg | 0 | 0 | 0.00%
Min Throughput | scroll | 42.11 | 43.07 | 2.28%
Mean Throughput | scroll | 42.17 | 43.13 | 2.28%
Median Throughput | scroll | 42.17 | 43.13 | 2.28%
Max Throughput | scroll | 42.21 | 43.2 | 2.35%
50th percentile latency | scroll | 23577.9 | 20240.5 | -14.15%
90th percentile latency | scroll | 27106.5 | 23192.2 | -14.44%
99th percentile latency | scroll | 27902.5 | 23801.3 | -14.70%
100th percentile latency | scroll | 27992.8 | 23868.2 | -14.73%
50th percentile service time | scroll | 581.932 | 566.945 | -2.58%
90th percentile service time | scroll | 587.971 | 575.465 | -2.13%
99th percentile service time | scroll | 600.431 | 584.803 | -2.60%
100th percentile service time | scroll | 606.659 | 594.415 | -2.02%
error rate | scroll | 0 | 0 | 0.00%
Min Throughput | query-string-on-message | 2 | 2 | 0.00%
Mean Throughput | query-string-on-message | 2 | 2 | 0.00%
Median Throughput | query-string-on-message | 2 | 2 | 0.00%
Max Throughput | query-string-on-message | 2 | 2 | 0.00%
50th percentile latency | query-string-on-message | 73.2224 | 71.2061 | -2.75%
90th percentile latency | query-string-on-message | 76.5044 | 74.9153 | -2.08%
99th percentile latency | query-string-on-message | 81.7366 | 85.4423 | 4.53%
100th percentile latency | query-string-on-message | 84.3834 | 98.3219 | 16.52%
50th percentile service time | query-string-on-message | 72.1775 | 69.9625 | -3.07%
90th percentile service time | query-string-on-message | 75.1373 | 73.5786 | -2.07%
99th percentile service time | query-string-on-message | 80.7465 | 84.4517 | 4.59%
100th percentile service time | query-string-on-message | 83.2789 | 97.527 | 17.11%
error rate | query-string-on-message | 0 | 0 | 0.00%
Min Throughput | query-string-on-message-filtered | 2 | 2 | 0.00%
Mean Throughput | query-string-on-message-filtered | 2 | 2 | 0.00%
Median Throughput | query-string-on-message-filtered | 2 | 2 | 0.00%
Max Throughput | query-string-on-message-filtered | 2 | 2 | 0.00%
50th percentile latency | query-string-on-message-filtered | 135.899 | 129.465 | -4.73%
90th percentile latency | query-string-on-message-filtered | 142.395 | 142.424 | 0.02%
99th percentile latency | query-string-on-message-filtered | 149.585 | 146.79 | -1.87%
100th percentile latency | query-string-on-message-filtered | 150.452 | 146.918 | -2.35%
50th percentile service time | query-string-on-message-filtered | 134.835 | 128.237 | -4.89%
90th percentile service time | query-string-on-message-filtered | 141.507 | 141.313 | -0.14%
99th percentile service time | query-string-on-message-filtered | 148.17 | 145.521 | -1.79%
100th percentile service time | query-string-on-message-filtered | 149.497 | 145.828 | -2.45%
error rate | query-string-on-message-filtered | 0 | 0 | 0.00%
Min Throughput | query-string-on-message-filtered-sorted-num | 2 | 2 | 0.00%
Mean Throughput | query-string-on-message-filtered-sorted-num | 2 | 2 | 0.00%
Median Throughput | query-string-on-message-filtered-sorted-num | 2 | 2 | 0.00%
Max Throughput | query-string-on-message-filtered-sorted-num | 2 | 2.01 | 0.50%
50th percentile latency | query-string-on-message-filtered-sorted-num | 87.0639 | 85.8384 | -1.41%
90th percentile latency | query-string-on-message-filtered-sorted-num | 87.8693 | 87.1133 | -0.86%
99th percentile latency | query-string-on-message-filtered-sorted-num | 91.6578 | 88.6322 | -3.30%
100th percentile latency | query-string-on-message-filtered-sorted-num | 92.9138 | 94.6069 | 1.82%
50th percentile service time | query-string-on-message-filtered-sorted-num | 84.8049 | 83.7309 | -1.27%
90th percentile service time | query-string-on-message-filtered-sorted-num | 85.5344 | 84.6912 | -0.99%
99th percentile service time | query-string-on-message-filtered-sorted-num | 89.6769 | 85.9782 | -4.12%
100th percentile service time | query-string-on-message-filtered-sorted-num | 90.2824 | 92.2853 | 2.22%
error rate | query-string-on-message-filtered-sorted-num | 0 | 0 | 0.00%
Min Throughput | sort_keyword_can_match_shortcut | 2.01 | 2.01 | 0.00%
Mean Throughput | sort_keyword_can_match_shortcut | 2.01 | 2.01 | 0.00%
Median Throughput | sort_keyword_can_match_shortcut | 2.01 | 2.01 | 0.00%
Max Throughput | sort_keyword_can_match_shortcut | 2.01 | 2.01 | 0.00%
50th percentile latency | sort_keyword_can_match_shortcut | 5.4609 | 5.59198 | 2.40%
90th percentile latency | sort_keyword_can_match_shortcut | 5.83507 | 6.02173 | 3.20%
99th percentile latency | sort_keyword_can_match_shortcut | 6.03453 | 6.18363 | 2.47%
100th percentile latency | sort_keyword_can_match_shortcut | 6.25904 | 6.71661 | 7.31%
50th percentile service time | sort_keyword_can_match_shortcut | 4.21648 | 4.38243 | 3.94%
90th percentile service time | sort_keyword_can_match_shortcut | 4.30521 | 4.48663 | 4.21%
99th percentile service time | sort_keyword_can_match_shortcut | 4.60167 | 4.93091 | 7.15%
100th percentile service time | sort_keyword_can_match_shortcut | 4.84133 | 5.24465 | 8.33%
error rate | sort_keyword_can_match_shortcut | 0 | 0 | 0.00%
Min Throughput | sort_keyword_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
Mean Throughput | sort_keyword_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
Median Throughput | sort_keyword_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
Max Throughput | sort_keyword_no_can_match_shortcut | 2.01 | 2.01 | 0.00%
50th percentile latency | sort_keyword_no_can_match_shortcut | 5.47201 | 5.66774 | 3.58%
90th percentile latency | sort_keyword_no_can_match_shortcut | 5.89648 | 6.03734 | 2.39%
99th percentile latency | sort_keyword_no_can_match_shortcut | 6.43242 | 6.2116 | -3.43%
100th percentile latency | sort_keyword_no_can_match_shortcut | 6.67006 | 6.31781 | -5.28%
50th percentile service time | sort_keyword_no_can_match_shortcut | 4.23463 | 4.42224 | 4.43%
90th percentile service time | sort_keyword_no_can_match_shortcut | 4.31062 | 4.51503 | 4.74%
99th percentile service time | sort_keyword_no_can_match_shortcut | 5.06791 | 4.59955 | -9.24%
100th percentile service time | sort_keyword_no_can_match_shortcut | 5.08333 | 4.70122 | -7.52%
error rate | sort_keyword_no_can_match_shortcut | 0 | 0 | 0.00%
Min Throughput | sort_numeric_desc | 2.01 | 2 | -0.50%
Mean Throughput | sort_numeric_desc | 2.01 | 2.01 | 0.00%
Median Throughput | sort_numeric_desc | 2.01 | 2.01 | 0.00%
Max Throughput | sort_numeric_desc | 2.01 | 2.01 | 0.00%
50th percentile latency | sort_numeric_desc | 10.695 | 34.826 | 225.63%
90th percentile latency | sort_numeric_desc | 11.1823 | 40.7785 | 264.67%
99th percentile latency | sort_numeric_desc | 11.3615 | 42.3213 | 272.50%
100th percentile latency | sort_numeric_desc | 11.3939 | 42.6249 | 274.10%
50th percentile service time | sort_numeric_desc | 9.42981 | 33.4261 | 254.47%
90th percentile service time | sort_numeric_desc | 9.75064 | 39.3821 | 303.89%
99th percentile service time | sort_numeric_desc | 10.0611 | 41.0883 | 308.39%
100th percentile service time | sort_numeric_desc | 10.0809 | 41.6012 | 312.67%
error rate | sort_numeric_desc | 0 | 0 | 0.00%
Min Throughput | sort_numeric_asc | 2.01 | 2.01 | 0.00%
Mean Throughput | sort_numeric_asc | 2.01 | 2.01 | 0.00%
Median Throughput | sort_numeric_asc | 2.01 | 2.01 | 0.00%
Max Throughput | sort_numeric_asc | 2.01 | 2.01 | 0.00%
50th percentile latency | sort_numeric_asc | 8.26669 | 34.5808 | 318.31%
90th percentile latency | sort_numeric_asc | 8.67153 | 36.5781 | 321.82%
99th percentile latency | sort_numeric_asc | 9.46224 | 39.4465 | 316.88%
100th percentile latency | sort_numeric_asc | 9.56789 | 45.3043 | 373.50%
50th percentile service time | sort_numeric_asc | 7.03573 | 33.3179 | 373.55%
90th percentile service time | sort_numeric_asc | 7.25778 | 35.3264 | 386.74%
99th percentile service time | sort_numeric_asc | 7.87195 | 38.2816 | 386.30%
100th percentile service time | sort_numeric_asc | 8.2661 | 43.8746 | 430.78%
error rate | sort_numeric_asc | 0 | 0 | 0.00%
Min Throughput | sort_numeric_desc_with_match | 2.01 | 2.01 | 0.00%
Mean Throughput | sort_numeric_desc_with_match | 2.01 | 2.01 | 0.00%
Median Throughput | sort_numeric_desc_with_match | 2.01 | 2.01 | 0.00%
Max Throughput | sort_numeric_desc_with_match | 2.01 | 2.01 | 0.00%
50th percentile latency | sort_numeric_desc_with_match | 3.97494 | 4.12637 | 3.81%
90th percentile latency | sort_numeric_desc_with_match | 4.33402 | 4.55853 | 5.18%
99th percentile latency | sort_numeric_desc_with_match | 4.51195 | 4.72296 | 4.68%
100th percentile latency | sort_numeric_desc_with_match | 4.67302 | 4.79647 | 2.64%
50th percentile service time | sort_numeric_desc_with_match | 2.75737 | 2.98795 | 8.36%
90th percentile service time | sort_numeric_desc_with_match | 2.81537 | 3.08216 | 9.48%
99th percentile service time | sort_numeric_desc_with_match | 2.95538 | 3.33583 | 12.87%
100th percentile service time | sort_numeric_desc_with_match | 3.03044 | 3.52255 | 16.24%
error rate | sort_numeric_desc_with_match | 0 | 0 | 0.00%
Min Throughput | sort_numeric_asc_with_match | 2.01 | 2.01 | 0.00%
Mean Throughput | sort_numeric_asc_with_match | 2.01 | 2.01 | 0.00%
Median Throughput | sort_numeric_asc_with_match | 2.01 | 2.01 | 0.00%
Max Throughput | sort_numeric_asc_with_match | 2.01 | 2.01 | 0.00%
50th percentile latency | sort_numeric_asc_with_match | 3.80288 | 4.17114 | 9.68%
90th percentile latency | sort_numeric_asc_with_match | 4.22217 | 4.60115 | 8.98%
99th percentile latency | sort_numeric_asc_with_match | 4.33849 | 4.68343 | 7.95%
100th percentile latency | sort_numeric_asc_with_match | 4.93657 | 4.69778 | -4.84%
50th percentile service time | sort_numeric_asc_with_match | 2.56098 | 2.93899 | 14.76%
90th percentile service time | sort_numeric_asc_with_match | 2.65866 | 3.00278 | 12.94%
99th percentile service time | sort_numeric_asc_with_match | 2.83601 | 3.12265 | 10.11%
100th percentile service time | sort_numeric_asc_with_match | 3.2459 | 3.14219 | -3.20%
error rate | sort_numeric_asc_with_match | 0 | 0 | 0.00%
Min Throughput | range_field_conjunction_big_range_big_term_query | 2.01 | 2.01 | 0.00%
Mean Throughput | range_field_conjunction_big_range_big_term_query | 2.01 | 2.01 | 0.00%
Median Throughput | range_field_conjunction_big_range_big_term_query | 2.01 | 2.01 | 0.00%
Max Throughput | range_field_conjunction_big_range_big_term_query | 2.01 | 2.01 | 0.00%
50th percentile latency | range_field_conjunction_big_range_big_term_query | 4.28146 | 3.88545 | -9.25%
90th percentile latency | range_field_conjunction_big_range_big_term_query | 4.67139 | 4.29026 | -8.16%
99th percentile latency | range_field_conjunction_big_range_big_term_query | 4.7573 | 4.41942 | -7.10%
100th percentile latency | range_field_conjunction_big_range_big_term_query | 4.82378 | 4.45351 | -7.68%
50th percentile service time | range_field_conjunction_big_range_big_term_query | 3.02292 | 2.58968 | -14.33%
90th percentile service time | range_field_conjunction_big_range_big_term_query | 3.08547 | 2.68364 | -13.02%
99th percentile service time | range_field_conjunction_big_range_big_term_query | 3.21099 | 3.03579 | -5.46%
100th percentile service time | range_field_conjunction_big_range_big_term_query | 3.25388 | 3.3379 | 2.58%
error rate | range_field_conjunction_big_range_big_term_query | 0 | 0 | 0.00%
Min Throughput | range_field_disjunction_big_range_small_term_query | 2.01 | 2.01 | 0.00%
Mean Throughput | range_field_disjunction_big_range_small_term_query | 2.01 | 2.01 | 0.00%
Median Throughput | range_field_disjunction_big_range_small_term_query | 2.01 | 2.01 | 0.00%
Max Throughput | range_field_disjunction_big_range_small_term_query | 2.01 | 2.01 | 0.00%
50th percentile latency | range_field_disjunction_big_range_small_term_query | 3.86352 | 3.87102 | 0.19%
90th percentile latency | range_field_disjunction_big_range_small_term_query | 4.28328 | 4.22897 | -1.27%
99th percentile latency | range_field_disjunction_big_range_small_term_query | 4.67012 | 4.50356 | -3.57%
100th percentile latency | range_field_disjunction_big_range_small_term_query | 5.13385 | 4.62785 | -9.86%
50th percentile service time | range_field_disjunction_big_range_small_term_query | 2.59304 | 2.61972 | 1.03%
90th percentile service time | range_field_disjunction_big_range_small_term_query | 2.67472 | 2.72586 | 1.91%
99th percentile service time | range_field_disjunction_big_range_small_term_query | 2.73911 | 2.89679 | 5.76%
100th percentile service time | range_field_disjunction_big_range_small_term_query | 2.76514 | 2.96374 | 7.18%
error rate | range_field_disjunction_big_range_small_term_query | 0 | 0 | 0.00%
Min Throughput | range_field_conjunction_small_range_small_term_query | 2.01 | 2.01 | 0.00%
Mean Throughput | range_field_conjunction_small_range_small_term_query | 2.01 | 2.01 | 0.00%
Median Throughput | range_field_conjunction_small_range_small_term_query | 2.01 | 2.01 | 0.00%
Max Throughput | range_field_conjunction_small_range_small_term_query | 2.01 | 2.01 | 0.00%
50th percentile latency | range_field_conjunction_small_range_small_term_query | 4.26315 | 4.22177 | -0.97%
90th percentile latency | range_field_conjunction_small_range_small_term_query | 4.74314 | 4.62861 | -2.41%
99th percentile latency | range_field_conjunction_small_range_small_term_query | 5.05643 | 4.78573 | -5.35%
100th percentile latency | range_field_conjunction_small_range_small_term_query | 5.08366 | 5.06775 | -0.31%
50th percentile service time | range_field_conjunction_small_range_small_term_query | 3.07047 | 2.94857 | -3.97%
90th percentile service time | range_field_conjunction_small_range_small_term_query | 3.12683 | 3.08948 | -1.19%
99th percentile service time | range_field_conjunction_small_range_small_term_query | 3.29883 | 3.6268 | 9.94%
100th percentile service time | range_field_conjunction_small_range_small_term_query | 3.34146 | 3.91749 | 17.24%
error rate | range_field_conjunction_small_range_small_term_query | 0 | 0 | 0.00%
Min Throughput | range_field_conjunction_small_range_big_term_query | 2.01 | 2.01 | 0.00%
Mean Throughput | range_field_conjunction_small_range_big_term_query | 2.01 | 2.01 | 0.00%
Median Throughput | range_field_conjunction_small_range_big_term_query | 2.01 | 2.01 | 0.00%
Max Throughput | range_field_conjunction_small_range_big_term_query | 2.01 | 2.01 | 0.00%
50th percentile latency | range_field_conjunction_small_range_big_term_query | 3.71854 | 4.22749 | 13.69%
90th percentile latency | range_field_conjunction_small_range_big_term_query | 4.13034 | 4.64126 | 12.37%
99th percentile latency | range_field_conjunction_small_range_big_term_query | 4.36855 | 4.89745 | 12.11%
100th percentile latency | range_field_conjunction_small_range_big_term_query | 4.6448 | 5.62289 | 21.06%
50th percentile service time | range_field_conjunction_small_range_big_term_query | 2.45527 | 2.96522 | 20.77%
90th percentile service time | range_field_conjunction_small_range_big_term_query | 2.62377 | 3.04993 | 16.24%
99th percentile service time | range_field_conjunction_small_range_big_term_query | 3.11558 | 3.27082 | 4.98%
100th percentile service time | range_field_conjunction_small_range_big_term_query | 3.34435 | 4.02592 | 20.38%
error rate | range_field_conjunction_small_range_big_term_query | 0 | 0 | 0.00%
Min Throughput | range-auto-date-histo | 0.21 | 0.22 | 4.76%
Mean Throughput | range-auto-date-histo | 0.21 | 0.22 | 4.76%
Median Throughput | range-auto-date-histo | 0.21 | 0.22 | 4.76%
Max Throughput | range-auto-date-histo | 0.21 | 0.22 | 4.76%
50th percentile latency | range-auto-date-histo | 1.06E+06 | 1.04E+06 | -2.20%
90th percentile latency | range-auto-date-histo | 1.23E+06 | 1.20E+06 | -2.22%
99th percentile latency | range-auto-date-histo | 1.27E+06 | 1.24E+06 | -2.24%
100th percentile latency | range-auto-date-histo | 1.27E+06 | 1.24E+06 | -2.24%
50th percentile service time | range-auto-date-histo | 4713.66 | 4631.65 | -1.74%
90th percentile service time | range-auto-date-histo | 4819.2 | 4666.06 | -3.18%
99th percentile service time | range-auto-date-histo | 4841.43 | 4706.22 | -2.79%
100th percentile service time | range-auto-date-histo | 4984.33 | 4709.57 | -5.51%
error rate | range-auto-date-histo | 0 | 0 | 0.00%
Min Throughput | range-auto-date-histo-with-metrics | 0.08 | 0.08 | 0.00%
Mean Throughput | range-auto-date-histo-with-metrics | 0.08 | 0.08 | 0.00%
Median Throughput | range-auto-date-histo-with-metrics | 0.08 | 0.08 | 0.00%
Max Throughput | range-auto-date-histo-with-metrics | 0.08 | 0.08 | 0.00%
50th percentile latency | range-auto-date-histo-with-metrics | 2.93E+06 | 2.89E+06 | -1.24%
90th percentile latency | range-auto-date-histo-with-metrics | 3.39E+06 | 3.35E+06 | -1.23%
99th percentile latency | range-auto-date-histo-with-metrics | 3.50E+06 | 3.45E+06 | -1.23%
100th percentile latency | range-auto-date-histo-with-metrics | 3.51E+06 | 3.47E+06 | -1.24%
50th percentile service time | range-auto-date-histo-with-metrics | 12206.8 | 12033.2 | -1.42%
90th percentile service time | range-auto-date-histo-with-metrics | 12507.9 | 12142.4 | -2.92%
99th percentile service time | range-auto-date-histo-with-metrics | 12584.7 | 12208.2 | -2.99%
100th percentile service time | range-auto-date-histo-with-metrics | 12608.5 | 12272.2 | -2.67%
error rate | range-auto-date-histo-with-metrics | 0 | 0 | 0.00%
Min Throughput | range-agg-1 | 2.01 | 2.01 | 0.00%
Mean Throughput | range-agg-1 | 2.01 | 2.01 | 0.00%
Median Throughput | range-agg-1 | 2.01 | 2.01 | 0.00%
Max Throughput | range-agg-1 | 2.01 | 2.01 | 0.00%
50th percentile latency | range-agg-1 | 4.21567 | 4.15675 | -1.40%
90th percentile latency | range-agg-1 | 4.62203 | 4.57139 | -1.10%
99th percentile latency | range-agg-1 | 4.76424 | 4.77626 | 0.25%
100th percentile latency | range-agg-1 | 4.80389 | 4.8704 | 1.38%
50th percentile service time | range-agg-1 | 2.95995 | 2.84804 | -3.78%
90th percentile service time | range-agg-1 | 3.0426 | 2.98711 | -1.82%
99th percentile service time | range-agg-1 | 3.19606 | 3.10761 | -2.77%
100th percentile service time | range-agg-1 | 3.28911 | 3.20811 | -2.46%
error rate | range-agg-1 | 0 | 0 | 0.00%
Min Throughput | range-agg-2 | 2.01 | 2.01 | 0.00%
Mean Throughput | range-agg-2 | 2.01 | 2.01 | 0.00%
Median Throughput | range-agg-2 | 2.01 | 2.01 | 0.00%
Max Throughput | range-agg-2 | 2.01 | 2.01 | 0.00%
50th percentile latency | range-agg-2 | 4.00132 | 4.28767 | 7.16%
90th percentile latency | range-agg-2 | 4.40774 | 4.53891 | 2.98%
99th percentile latency | range-agg-2 | 4.58269 | 4.89486 | 6.81%
100th percentile latency | range-agg-2 | 4.65026 | 5.32344 | 14.48%
50th percentile service time | range-agg-2 | 2.79944 | 3.13436 | 11.96%
90th percentile service time | range-agg-2 | 2.86394 | 3.21871 | 12.39%
99th percentile service time | range-agg-2 | 2.94224 | 3.31214 | 12.57%
100th percentile service time | range-agg-2 | 3.02189 | 3.5814 | 18.52%
error rate | range-agg-2 | 0 | 0 | 0.00%
Min Throughput | cardinality-agg-low | 2.01 | 2.01 | 0.00%
Mean Throughput | cardinality-agg-low | 2.01 | 2.01 | 0.00%
Median Throughput | cardinality-agg-low | 2.01 | 2.01 | 0.00%
Max Throughput | cardinality-agg-low | 2.01 | 2.01 | 0.00%
50th percentile latency | cardinality-agg-low | 6.28732 | 6.35106 | 1.01%
90th percentile latency | cardinality-agg-low | 6.59756 | 6.91635 | 4.83%
99th percentile latency | cardinality-agg-low | 6.96813 | 7.158 | 2.72%
100th percentile latency | cardinality-agg-low | 7.30604 | 7.78943 | 6.62%
50th percentile service time | cardinality-agg-low | 4.9451 | 5.19854 | 5.13%
90th percentile service time | cardinality-agg-low | 5.1227 | 5.35106 | 4.46%
99th percentile service time | cardinality-agg-low | 5.7677 | 5.90342 | 2.35%
100th percentile service time | cardinality-agg-low | 5.85723 | 6.36227 | 8.62%
error rate | cardinality-agg-low | 0 | 0 | 0.00%
Min Throughput | cardinality-agg-high | 0.83 | 0.84 | 1.20%
Mean Throughput | cardinality-agg-high | 0.83 | 0.84 | 1.20%
Median Throughput | cardinality-agg-high | 0.83 | 0.84 | 1.20%
Max Throughput | cardinality-agg-high | 0.83 | 0.84 | 1.20%
50th percentile latency | cardinality-agg-high | 176230 | 173490 | -1.55%
90th percentile latency | cardinality-agg-high | 204176 | 200848 | -1.63%
99th percentile latency | cardinality-agg-high | 210394 | 207021 | -1.60%
100th percentile latency | cardinality-agg-high | 211101 | 207691 | -1.62%
50th percentile service time | cardinality-agg-high | 1197.59 | 1185.73 | -0.99%
90th percentile service time | cardinality-agg-high | 1231.47 | 1212.52 | -1.54%
99th percentile service time | cardinality-agg-high | 1251.08 | 1233.12 | -1.44%
100th percentile service time | cardinality-agg-high | 1266.98 | 1233.27 | -2.66%
error rate | cardinality-agg-high | 0 | 0 | 0.00%



</body>

</html>
